### PR TITLE
Allow for pre-approved pkgs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.0.0.9001
+Version: 0.0.0.9002
 Authors@R: 
   c(
     person(

--- a/R/utils.R
+++ b/R/utils.R
@@ -462,10 +462,23 @@ build_decisions_df <- function(
 #' @keywords internal
 get_case_whens <- function(met_dec_df, met_names, else_cat, ids = FALSE, auto_accept = FALSE) {
   
+  # for debugging
+  # met_dec_df <- build_decisions_df() |> dplyr::mutate(derived_col = metric)
+  # met_names <- c("dwnlds")
+  # else_cat <- "High"
+  # ids <- FALSE
+  # ids <- TRUE
+  # auto_accept <- TRUE
+  # auto_accept <- FALSE
+  
   # If auto_accept is TRUE, Then set ids to FALSE
   if(auto_accept) {
     ids <- FALSE
   }
+  
+  # if pkg was accepted outside of val.pipeline, we'll need to add logic to
+  # auto_accept those packages
+  approved_pkgs <- pull_config(val = "approved_pkgs", rule_type = "default")
   
   cond_exprs <- purrr::map_chr(met_names, ~ {
     # .x <- met_names[1]
@@ -478,26 +491,42 @@ get_case_whens <- function(met_dec_df, met_names, else_cat, ids = FALSE, auto_ac
         else_cat <- met_dec_df$decision_id[which(met_dec_df$decision == else_cat)] |> unique()
       } 
     }
-    # if we want the "auto_accept" version of case_when()'s then we'll want to leave
-    if(auto_accept) else_cat <- FALSE else else_cat <- glue::glue("'{else_cat}'")
     
+    # insert a '.x' in place of .x so that the variable name takes is place
     conds <- gsub('.x', .x, dec_df$condition)
-    if(all(!is.na(dec_df$auto_accept))) {
+    
+    # create a 'then' for the if-else-then response based on ids or auto_accept
+    then <- if(ids) min(dec_df$decision_id) else {
+      if(auto_accept) TRUE else glue::glue("'{levels(dec_df$decision)[1]}'")
+    }
+    
+    # Same here: create the appropriate 'else_cat'
+    else_cat <- if(ids) else_cat else {
+      if(auto_accept) FALSE else glue::glue("'{else_cat}'")
+    }
+    
+    # if pkg was accepted outside of val.pipeline, we'll need to accept it here:
+    if(!is.null(approved_pkgs) & length(approved_pkgs) > 0) {
+      approved_pkgs_cond <- glue::glue("package %in% c('{paste(approved_pkgs, collapse = \"', '\")}') ~ {then}")
+    } else {
+      approved_pkgs_cond <- NULL
+    }
+    
+    # if there's an auto_accept condition, generate a condition for it
+    if(any(!is.na(dec_df$auto_accept))) {
       aa_cond <- gsub('.x', .x, dec_df$auto_accept) |> unique()
-      if(auto_accept) {
-        # TRUE / FALSE condition
-        auto_accept_cond <- glue::glue("{gsub('~', '', aa_cond)} ~ TRUE")
-      } else {
-        # Decision (id) outcome:
-        auto_accept_cond <- glue::glue("{gsub('~', '', aa_cond)} ~ '{if(ids) min(dec_df$decision_id) else levels(dec_df$decision)[1]}'")
-      }
+      auto_accept_cond <- glue::glue("{gsub('~', '', aa_cond)} ~ {then}")
     } else {
       auto_accept_cond <- NULL
     }
     
+    # build case_when statements!
+    # via: approved_pkgs, auto_accept, and decision conds, in that order
     c(
-      auto_accept_cond, # include a condition for auto_accepted categories, which should be run first
-      if(auto_accept) NULL else glue::glue("{gsub('~', '', conds)} ~ '{if(ids) dec_df$decision_id else dec_df$decision}'"),
+      # include a condition(s) for auto_accepted categories, which should be run first
+      if(auto_accept) c(approved_pkgs_cond, auto_accept_cond),
+      # otherwise, regular metric-based conditions
+      if(auto_accept) NULL else glue::glue("{gsub('~', '', conds)} ~ {if(ids) dec_df$decision_id else paste0('\"', dec_df$decision, '\"')}"),
       glue::glue(".default = {else_cat}")
     ) |>
       stringr::str_flatten_comma() %>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -506,7 +506,7 @@ get_case_whens <- function(met_dec_df, met_names, else_cat, ids = FALSE, auto_ac
     }
     
     # if pkg was accepted outside of val.pipeline, we'll need to accept it here:
-    if(!is.null(approved_pkgs) & length(approved_pkgs) > 0) {
+    if(length(approved_pkgs) > 0) {
       approved_pkgs_cond <- glue::glue("package %in% c('{paste(approved_pkgs, collapse = \"', '\")}') ~ {then}")
     } else {
       approved_pkgs_cond <- NULL

--- a/R/val_pipeline.R
+++ b/R/val_pipeline.R
@@ -86,8 +86,6 @@ val_pipeline <- function(
   #
   # ---- Set capture 'old' options ----
   #
-  
-  # TO-DO: this should be moved inside val_categorize()
   old <- options()
   on.exit(function() options(old))
 

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -435,19 +435,17 @@ val_pkg <- function(
       dplyr::select(dplyr::ends_with("cataa")) |>
       names() %>%
       gsub("_cataa", "", .)
-    aa_mets <- aa_metrics |>
-      paste(collapse = ", ") %>%
-      paste("Auto-accepted metrics:", .)
+
     decision_reason <- dplyr::case_when(
       pkg %in% approved_pkgs ~ "Pre-Approved package",
-      length(aa_metrics) > 0 ~ paste0("Met 'Auto-accepted' threshold for '", aa_mets, "' metric(s)"),
+      length(aa_metrics) > 0 ~ paste("Met auto-accepted metric threshold(s) for:", paste(aa_metrics, collapse = ", ")),
       TRUE ~ "Risk Assessment"
     ) 
   } else {
     decision_reason <- "Risk Assessment"
   }
   
-  cat("\n-->", pkg_v,"decision reason:", decision_reason, "\n")
+  cat("\n-->", pkg_v,"decision reason:\n---->", decision_reason, "\n")
   
   #
   # ---- Build Report ----

--- a/dev/dev_build.R
+++ b/dev/dev_build.R
@@ -3,12 +3,41 @@
 devtools::load_all()
 
 # Create qualified pkg data.frame
-# trying to just do bioconductor packages
-qual <- val_pipeline(
+source("dev/pkg_lists.R") # build_pkgs & pkgs for CRAN only
+# See the full dependency tree before running val_build()
+# these_pkgs <- "withr"  # messes with the entire process
+# these_pkgs <- "matrix" # takes 5 mins to install
+# these_pkgs <- "askpass"
+these_pkgs <- "dplyr"
+# these_pkgs <- build_pkgs
+
+tree <- tools::package_dependencies(
+  packages = these_pkgs,
+  db = available.packages(),
+  # which = c("Suggests"),
+  which = "strong", #c("Depends", "Imports", "LinkingTo"),
+  # which = c("Depends", "Imports", "LinkingTo", "Suggests"), # prod
+  recursive = TRUE
+  # recursive = FALSE
+) |>
+  unlist(use.names = FALSE) |>
+  unique()
+# How many? # 621 pkgs -->  When recursive: 2,570. Only 744 when you don't include Suggests
+full_tree <- c(these_pkgs, tree) |> unique()
+full_tree |> length()
+
+# temporary until we can figure out what's gone haywire with this pkg
+# build_pkgs <- build_pkgs[build_pkgs != "withr"]
+
+qual <- val_build(
+  # pkg_names = build_pkgs,
+  pkg_names = "dplyr",
   ref = "source",
   metric_pkg = "riskmetric", 
-  deps = "depends", # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
-  deps_recursive = TRUE,
+  # deps = "depends", # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
+  deps = NULL,
+  # deps_recursive = TRUE,
+  deps_recursive = FALSE,
   val_date = Sys.Date(),
   # val_date = as.Date("2025-10-07"),
   replace = FALSE, 

--- a/dev/dev_pipeline.R
+++ b/dev/dev_pipeline.R
@@ -8,8 +8,8 @@ qual <- val_pipeline(
   metric_pkg = "riskmetric", 
   deps = "depends", # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
   deps_recursive = TRUE,
-  # val_date = Sys.Date(),
-  val_date = as.Date("2025-10-07"),
+  val_date = Sys.Date(),
+  # val_date = as.Date("2025-10-07"),
   replace = FALSE, 
   out = 'dev/riskassessments'
 )

--- a/dev/dev_play.R
+++ b/dev/dev_play.R
@@ -59,6 +59,7 @@ qual <- val_pipeline(
 # ---- val_build()----
 #
 
+source("dev/pkg_lists.R") # # build_pkgs & pkgs
 # See the full dependency tree before running val_build()
 # these_pkgs <- "withr"  # messes with the entire process
 # these_pkgs <- "matrix" # takes 5 mins to install
@@ -122,24 +123,25 @@ reports |> length()
 any(stringr::str_detect(reports, "spacesXYZ"))
 
 
-source("dev/pkg_lists.R")
+source("dev/pkg_lists.R") # build_pkgs & pkgs
 
 
-# pack = 'rlang'
+pack = 'dplyr'
 # pack = 'askpass' # 2.5 - 3 mins when deps, 2 pkgs, no prompts
 # pack = 'withr'
 # pack = 'SuppDists'
 
-pack <- pkgs[which(pkgs == "SuppDists") + 1] # last left off:
-pack
+# pack <- pkgs[which(pkgs == "SuppDists") + 1] # last left off:
+# pack
 
 pkg_meta <- val_pkg(
   pkg = pack,
   ver = avail_pkgs$Version[avail_pkgs$Package == pack],
   avail_pkgs = avail_pkgs,
-  ref = if(pkg %in% remote_pkgs) 'remote' else 'source',
+  ref = if(pack %in% remote_pkgs) 'remote' else 'source',
   metric_pkg = "riskmetric", 
   out_dir = val_dir,
   val_date = val_date
   )
-  
+# names(pkg_meta)
+pkg_meta[!names(pkg_meta) %in% c("rev_deps", "depends", "suggests")]

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -1,6 +1,6 @@
 default:
   remote_only: [withr, VGAM, shinyBS] # withr - crashes, VGAM ran 10 hrs, shinyBS 5 hrs
-  approved_pkgs: [dplyr] # packages that have been approved manually outside of {val.pipeline} workflow
+  approved_pkgs: [] # packages that have been approved manually outside of {val.pipeline} workflow
   decisions_lst: [Low, Medium, High]
   opt_repos: 
     CRAN: !expr paste0("https://packagemanager.posit.co/cran/", Sys.Date())

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -1,6 +1,6 @@
 default:
   remote_only: [withr, VGAM, shinyBS] # withr - crashes, VGAM ran 10 hrs, shinyBS 5 hrs
-  approved_pkgs: [] # packages that have been approved manually outside of {val.pipeline} workflow
+  approved_pkgs: [dplyr] # packages that have been approved manually outside of {val.pipeline} workflow
   decisions_lst: [Low, Medium, High]
   opt_repos: 
     CRAN: !expr paste0("https://packagemanager.posit.co/cran/", Sys.Date())


### PR DESCRIPTION
Closes the following:
- #2 

For `dplyr`, with no pkgs added added to the `approved_pkgs` config:

<img width="317" height="68" alt="image" src="https://github.com/user-attachments/assets/cb40f02d-86c6-4d72-b706-745a01f29176" />


Then, if you add `dplyr` to the `approved_pkgs` config field:

<img width="645" height="140" alt="image" src="https://github.com/user-attachments/assets/eaf60748-c521-4d45-bfa7-2a7d64d1f289" />

