### PR TITLE
Fix aa_metrics scope bug in val_pkg() decision_reason_note

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # val.pipeline (development version)
 
+- **Bug fix**: `val_pkg()` (and therefore `val_pipeline()` / `val_build()`) no
+longer crashes with `Error in dplyr::case_when(): object 'aa_metrics' not
+found` when processing a package whose initial assessment doesn't hit any
+auto-accept threshold. `dplyr::case_when()` eagerly evaluates every RHS
+expression regardless of which LHS matches, so referencing `aa_metrics`
+inside a case that was only meant to fire when `decision_aa` is `TRUE`
+still tries to evaluate `paste(aa_metrics, collapse = ", ")` on the
+non-auto-accept path — where `aa_metrics` was never defined. Regression
+introduced in #37 (`decision_reason_note` with driver metrics). Fixed by
+initialising `aa_metrics <- character(0)` unconditionally before the
+`if(decision_aa)` block.
+
 - All `val_*` entry points (`val_pipeline()`, `val_build()`, `val_pkg()`,
 `val_categorize()`, `val_decision()`, `val_pipeline_report()`) gain a
 new `verbose` argument that dials console output up or down without

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -448,7 +448,17 @@ val_pkg <- function(
   decision_aa <- decision |>
     dplyr::select(dplyr::ends_with("cataa")) |>
     as.vector() |> unlist() |> any()
-  
+
+  # Initialize `aa_metrics` unconditionally so the eager-evaluated
+  # `dplyr::case_when()` RHS below (see `decision_reason_note`) can
+  # always reference it even when no auto-accept threshold matched
+  # (i.e. when `decision_aa` is FALSE). Without this, packages that
+  # don't auto-accept trigger:
+  #   Error in dplyr::case_when(): object 'aa_metrics' not found
+  # because case_when() evaluates every RHS expression before
+  # selecting which one to use.
+  aa_metrics <- character(0)
+
   if(decision_aa) {
     approved_pkgs <- pull_config(val = "approved_pkgs", rule_type = "default")
     aa_metrics <- decision |>


### PR DESCRIPTION
## The bug

`val_pipeline()` crashes on any package whose initial `pkg_cran_remote` assessment doesn't hit an auto-accept threshold — e.g. `askpass` at package #56 in the reporter's run:

```
Error in `purrr::map2()` at rlang/R/attr.R:198:3:
i In index: 56.
Caused by error in `dplyr::case_when()` at val.pipeline/R/val_pkg.R:475:3:
! Failed to evaluate the right-hand side of formula 1.
Caused by error:
! object 'aa_metrics' not found.
```

## Root cause

`dplyr::case_when()` evaluates **every** RHS expression up-front and only *then* selects which value to return per LHS match — it does not short-circuit. In `val_pkg.R`:

```r
if(decision_aa) {
  aa_metrics <- decision |> ... |> gsub("_cataa", "", .)
  decision_reason <- ...
} else {
  decision_reason <- "Risk Assessment"     # <-- aa_metrics never defined here
}

decision_reason_note <- dplyr::case_when(
  identical(decision_reason, "Auto-Accepted") ~
    paste(aa_metrics, collapse = ", "),                     # <-- always evaluated
  identical(decision_reason, "Risk Assessment") ~
    extract_risk_drivers(decision, decisions = decisions),
  .default = NA_character_
)
```

On the `else` path (no auto-accept match), `paste(aa_metrics, ...)` still runs and errors with `object 'aa_metrics' not found`, even though its LHS is `FALSE`.

Reproduced independently in isolation:

```r
decision_aa <- FALSE
if(decision_aa) { aa_metrics <- c("x"); decision_reason <- "Auto-Accepted" } else { decision_reason <- "Risk Assessment" }
dplyr::case_when(
  identical(decision_reason, "Auto-Accepted") ~ paste(aa_metrics, collapse = ", "),
  identical(decision_reason, "Risk Assessment") ~ "risk-driven",
  .default = NA_character_
)
#> Error: object 'aa_metrics' not found
```

## Origin

Regression introduced in **#37** ("Add `decision_reason_note` with driver metrics / failing deps"), commit `f57a9d4`. It's been latent since — only surfaces on packages that reach `val_pkg()` and fail to hit any auto-accept threshold. `askpass` is one of the first pkgs alphabetically in that bucket, so most full runs would hit this early.

## Fix

Initialise `aa_metrics <- character(0)` unconditionally, before the `if(decision_aa)` block, so eager RHS evaluation always finds it:

```r
# Initialize `aa_metrics` unconditionally so the eager-evaluated
# `dplyr::case_when()` RHS below (see `decision_reason_note`) can
# always reference it even when no auto-accept threshold matched
# (i.e. when `decision_aa` is FALSE). Without this, packages that
# don't auto-accept trigger:
#   Error in dplyr::case_when(): object 'aa_metrics' not found
# because case_when() evaluates every RHS expression before
# selecting which one to use.
aa_metrics <- character(0)

if(decision_aa) {
  # ... assigns aa_metrics from the assessment ...
}
```

The inline comment documents the invariant and points at the `case_when()` gotcha so this doesn't regress again.

## Behaviour after the fix

- Non-auto-accept path: `aa_metrics` is `character(0)`, `case_when()`'s eager `paste(character(0), collapse = ", ")` produces `""` (safe — LHS is FALSE, so the value is discarded), and the actual selected value is `extract_risk_drivers(...)` from the `"Risk Assessment"` branch. ✅
- Auto-accept path: `aa_metrics` gets reassigned inside the `if` block, `case_when()` selects the `"Auto-Accepted"` branch, and the note lists the auto-accept metric names. ✅

## Verification

- Reproduced the bug in isolation with the pre-fix pattern; confirmed the fix removes the error.
- Verified the auto-accept path still returns the correct metric-name list.
- Full `val_*` test suite passes (85/85, no regressions).

## Testing note

A proper unit test for this exact `val_pkg()` internal would require heavy mocking of `riskmetric::pkg_ref` / `pkg_assess` / `pkg_score` and the `val_decision()` output shape (specifically, `decision` needing zero `_cataa` columns for the bug to trigger). The inline comment captures the invariant instead. Long-term this block would be worth extracting into a small helper for direct testing.
