### PR TITLE
Add position counter and HH:MM timestamp to minimal-tier per-package line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,25 @@
 # val.pipeline (development version)
 
+- **Enhancement (`verbose = "minimal"`)**: the per-package summary line
+now leads with an abbreviated `[HH:MM]` timestamp (US/Eastern) and a
+right-aligned `(idx/total)` position counter so long `val_build()` runs
+show at a glance both when each package landed and how far into the
+list we are. Format is now roughly:
+
+  ```
+     [09:25] (   1/1195) [Low]     dplyr v1.1.4          (12s)
+     [09:25] (   2/1195) [Medium]  ggplot2 v3.5.1        (2m 18s)
+     ...
+     [10:47] (1195/1195) [Low]     zoo v1.8-12           (3s)
+  ```
+
+  Implemented via new optional `pkg_idx` / `pkg_total` / `timestamp`
+  args on `val_pkg_summary_line()`; `val_build()` threads the counter
+  through to all three summary-line call sites (the cached, dep-skip,
+  and normal branches). Standalone `val_pkg()` calls (which don't know
+  where they sit in a run) still render the timestamp and omit the
+  counter cleanly rather than printing `(NA/NA)`.
+
 - **Bug fix**: `val_pkg()` (and therefore `val_pipeline()` / `val_build()`) no
 longer crashes with `Error in dplyr::case_when(): object 'aa_metrics' not
 found` when processing a package whose initial assessment doesn't hit any

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -277,7 +277,9 @@ val_build <- function(
           ref = if(pkg %in% remote_pkgs) 'remote' else ref,
           metric_pkg = metric_pkg,
           out_dir = val_dir,
-          val_date = val_date)
+          val_date = val_date,
+          pkg_idx = pkg_cnt,
+          pkg_total = pkgs_length)
       } else {
         val_msg(paste0("\nAttempted New Package: ", pkg, " v", ver,", but already assessed.\n\n"),
                 min_level = "normal")
@@ -285,7 +287,10 @@ val_build <- function(
 
         val_msg("\n-->", pkg_v,"Using assessment previously stored.\n",
                 min_level = "normal")
-        val_pkg_summary_line(pkg, ver, pkg_meta$decision, suffix = "(cached)")
+        val_pkg_summary_line(pkg, ver, pkg_meta$decision,
+                             suffix = "(cached)",
+                             pkg_idx = pkg_cnt,
+                             pkg_total = pkgs_length)
       }
       
       # if a pkg fails, make sure it's reverse dependencies don't run an assessment
@@ -361,7 +366,10 @@ val_build <- function(
       # save the pkg_meta
       saveRDS(pkg_meta, pkg_meta_file)
       val_msg("\n-->", pkg_v,"meta bundle saved.\n", min_level = "verbose")
-      val_pkg_summary_line(pkg, ver, pkg_meta$decision, suffix = "(dep-skip)")
+      val_pkg_summary_line(pkg, ver, pkg_meta$decision,
+                           suffix = "(dep-skip)",
+                           pkg_idx = pkg_cnt,
+                           pkg_total = pkgs_length)
     }
     
     # return!

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -23,6 +23,12 @@
 #'   `"minimal"`, `"normal"` (default), or `"verbose"`. See
 #'   the `val.pipeline` verbosity docs for tier definitions. Defaults to whatever the
 #'   session option `val.pipeline.verbose` is set to (or `"normal"`).
+#' @param pkg_idx,pkg_total Integer(1) or `NULL`. Optional
+#'   position-in-run counter surfaced on the `verbose = "minimal"`
+#'   summary line as `"(<pkg_idx>/<pkg_total>)"`. Populated
+#'   automatically when `val_pkg()` is called from inside
+#'   [val_build()]'s per-package loop; leave as `NULL` when calling
+#'   `val_pkg()` standalone.
 #'
 #' @importFrom glue glue
 #' @importFrom utils download.file untar capture.output
@@ -43,7 +49,9 @@ val_pkg <- function(
     metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
     out_dir,
     val_date = Sys.Date(),
-    verbose = NULL
+    verbose = NULL,
+    pkg_idx = NULL,
+    pkg_total = NULL
 ) {
   # i <- 1 # for debugging
   # pkg <- pkgs[i] # for debugging
@@ -560,7 +568,9 @@ val_pkg <- function(
   saveRDS(meta_list, file.path(assessed, glue::glue("{pkg_v}_meta.rds")))
   val_msg("\n-->", pkg_v,"meta bundle saved.\n", min_level = "normal")
   val_pkg_summary_line(pkg, ver, decision$final_risk,
-                       elapsed_secs = as.numeric(ass_mins, units = "secs"))
+                       elapsed_secs = as.numeric(ass_mins, units = "secs"),
+                       pkg_idx = pkg_idx,
+                       pkg_total = pkg_total)
   
   return(meta_list)
 }

--- a/R/verbosity.R
+++ b/R/verbosity.R
@@ -158,13 +158,53 @@ val_print <- function(x, min_level = "normal", ...) {
 #'   non-`NULL`. Pass `NULL` for skipped / cached packages.
 #' @param suffix Character(1), optional trailing tag (e.g.
 #'   `"(cached)"`, `"(dep-skip)"`) rendered after the elapsed time.
+#' @param pkg_idx,pkg_total Integer(1) or `NULL`. Optional
+#'   position-in-run counter (e.g. `1` and `1195`) rendered as
+#'   `"(1/1195)"` between the timestamp and the decision tag.
+#'   When either is `NULL` (the default), the counter is omitted so
+#'   standalone callers (e.g. a direct `val_pkg()` call outside a
+#'   `val_build()` loop) don't need to fabricate a fake index.
+#' @param timestamp `POSIXct(1)`, `character(1)`, or `NULL`. Optional
+#'   wall-clock stamp for when this package's summary is emitted.
+#'   Rendered as `"[HH:MM]"` in `US/Eastern`. When `NULL` (the
+#'   default), `Sys.time()` is used so callers don't have to compute
+#'   it themselves.
 #' @keywords internal
 val_pkg_summary_line <- function(pkg,
                                  ver,
                                  decision,
                                  elapsed_secs = NULL,
-                                 suffix = NULL) {
+                                 suffix = NULL,
+                                 pkg_idx = NULL,
+                                 pkg_total = NULL,
+                                 timestamp = NULL) {
   if (!val_verbosity_at_least("minimal")) return(invisible(NULL))
+
+  # Wall-clock stamp. Compute here rather than in the caller so every
+  # summary line reflects the moment it actually prints, not the
+  # moment the package started assessing (which for slow pkgs can be
+  # tens of minutes apart).
+  if (is.null(timestamp)) timestamp <- Sys.time()
+  ts_str <- if (inherits(timestamp, c("POSIXct", "POSIXlt", "POSIXt"))) {
+    format(timestamp, "%H:%M", tz = "US/Eastern")
+  } else if (is.character(timestamp) && length(timestamp) == 1L) {
+    timestamp
+  } else {
+    format(Sys.time(), "%H:%M", tz = "US/Eastern")
+  }
+  ts_str <- paste0("[", ts_str, "]")
+
+  # Position-in-run counter. Rendered right-aligned so long runs stay
+  # visually columnar (e.g. `   (1/1195)` vs `(1195/1195)`).
+  if (!is.null(pkg_idx) && !is.null(pkg_total) &&
+      is.finite(as.numeric(pkg_idx)) &&
+      is.finite(as.numeric(pkg_total))) {
+    total_w <- nchar(as.character(pkg_total))
+    idx_str <- formatC(as.character(pkg_idx), width = total_w)
+    counter_str <- paste0("(", idx_str, "/", pkg_total, ") ")
+  } else {
+    counter_str <- ""
+  }
 
   dec_str <- formatC(paste0("[", as.character(decision), "]"),
                      width = 9, flag = "-")
@@ -184,7 +224,7 @@ val_pkg_summary_line <- function(pkg,
     paste0(" ", suffix)
   }
 
-  cat(paste0("   ", dec_str, " ", pkg_v_str, " ",
+  cat(paste0("   ", ts_str, " ", counter_str, dec_str, " ", pkg_v_str, " ",
              elapsed_str, suffix_str, "\n"))
   invisible(NULL)
 }

--- a/man/val_pkg.Rd
+++ b/man/val_pkg.Rd
@@ -12,7 +12,9 @@ val_pkg(
   metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
   out_dir,
   val_date = Sys.Date(),
-  verbose = NULL
+  verbose = NULL,
+  pkg_idx = NULL,
+  pkg_total = NULL
 )
 }
 \arguments{
@@ -37,6 +39,13 @@ package directly from the repo.}
 \code{"minimal"}, \code{"normal"} (default), or \code{"verbose"}. See
 the \code{val.pipeline} verbosity docs for tier definitions. Defaults to whatever the
 session option \code{val.pipeline.verbose} is set to (or \code{"normal"}).}
+
+\item{pkg_idx, pkg_total}{Integer(1) or \code{NULL}. Optional
+position-in-run counter surfaced on the \code{verbose = "minimal"}
+summary line as \code{"(<pkg_idx>/<pkg_total>)"}. Populated
+automatically when \code{val_pkg()} is called from inside
+\code{\link[=val_build]{val_build()}}'s per-package loop; leave as \code{NULL} when calling
+\code{val_pkg()} standalone.}
 }
 \value{
 A list containing package metadata, assessment results, and

--- a/man/val_pkg_summary_line.Rd
+++ b/man/val_pkg_summary_line.Rd
@@ -4,7 +4,16 @@
 \alias{val_pkg_summary_line}
 \title{Emit a one-line-per-package summary at the "minimal" tier}
 \usage{
-val_pkg_summary_line(pkg, ver, decision, elapsed_secs = NULL, suffix = NULL)
+val_pkg_summary_line(
+  pkg,
+  ver,
+  decision,
+  elapsed_secs = NULL,
+  suffix = NULL,
+  pkg_idx = NULL,
+  pkg_total = NULL,
+  timestamp = NULL
+)
 }
 \arguments{
 \item{pkg, ver}{Character(1). Package name and version.}
@@ -18,6 +27,19 @@ non-\code{NULL}. Pass \code{NULL} for skipped / cached packages.}
 
 \item{suffix}{Character(1), optional trailing tag (e.g.
 \code{"(cached)"}, \code{"(dep-skip)"}) rendered after the elapsed time.}
+
+\item{pkg_idx, pkg_total}{Integer(1) or \code{NULL}. Optional
+position-in-run counter (e.g. \code{1} and \code{1195}) rendered as
+\code{"(1/1195)"} between the timestamp and the decision tag.
+When either is \code{NULL} (the default), the counter is omitted so
+standalone callers (e.g. a direct \code{val_pkg()} call outside a
+\code{val_build()} loop) don't need to fabricate a fake index.}
+
+\item{timestamp}{\code{POSIXct(1)}, \code{character(1)}, or \code{NULL}. Optional
+wall-clock stamp for when this package's summary is emitted.
+Rendered as \code{"[HH:MM]"} in \code{US/Eastern}. When \code{NULL} (the
+default), \code{Sys.time()} is used so callers don't have to compute
+it themselves.}
 }
 \description{
 Formats a compact "\code{   [decision]  <pkg> v<ver>  (elapsed)}"

--- a/tests/testthat/test-verbosity.R
+++ b/tests/testthat/test-verbosity.R
@@ -113,8 +113,11 @@ test_that("val_pkg_summary_line() formats compactly at minimal+, stays silent at
     val_pkg_summary_line("dplyr", "1.1.4", "Low", elapsed_secs = 12)
   )
   expect_length(out, 1L)
-  expect_match(out, "^\\s+\\[Low\\]\\s+dplyr v1\\.1\\.4")
+  # Timestamp bracket + decision + pkg + elapsed. No counter when pkg_idx
+  # / pkg_total are NULL (standalone-call default).
+  expect_match(out, "^\\s+\\[\\d{2}:\\d{2}\\]\\s+\\[Low\\]\\s+dplyr v1\\.1\\.4")
   expect_match(out, "\\(12s\\)$")
+  expect_false(grepl("/", out))  # no counter
 
   # medium/high tags and suffix
   expect_output(
@@ -133,6 +136,70 @@ test_that("val_pkg_summary_line() formats compactly at minimal+, stays silent at
     val_pkg_summary_line("cli", "3.6.1", "Low", elapsed_secs = 5),
     regexp = NA
   )
+})
+
+
+test_that("val_pkg_summary_line() renders position-in-run counter when supplied", {
+  op <- options(val.pipeline.verbose = "minimal")
+  on.exit(options(op), add = TRUE)
+
+  # Right-aligns the index to the total's character width so long
+  # runs stay visually columnar.
+  out1 <- capture.output(
+    val_pkg_summary_line("dplyr", "1.1.4", "Low", elapsed_secs = 12,
+                         pkg_idx = 1, pkg_total = 1195)
+  )
+  expect_match(out1, "\\(   1/1195\\)")
+
+  out2 <- capture.output(
+    val_pkg_summary_line("last", "9.9.9", "Low", elapsed_secs = 3,
+                         pkg_idx = 1195, pkg_total = 1195)
+  )
+  expect_match(out2, "\\(1195/1195\\)")
+
+  # Small totals get correspondingly narrow indices.
+  out3 <- capture.output(
+    val_pkg_summary_line("cli", "3.6.1", "Low", elapsed_secs = 5,
+                         pkg_idx = 3, pkg_total = 7)
+  )
+  expect_match(out3, "\\(3/7\\)")
+
+  # Partial input (only one of the two) omits the counter rather than
+  # rendering something misleading like "(NA/10)".
+  out4 <- capture.output(
+    val_pkg_summary_line("x", "1", "Low",
+                         pkg_idx = 3, pkg_total = NULL)
+  )
+  expect_false(grepl("/", out4))
+})
+
+
+test_that("val_pkg_summary_line() renders an abbreviated HH:MM timestamp", {
+  op <- options(val.pipeline.verbose = "minimal")
+  on.exit(options(op), add = TRUE)
+
+  # Explicit POSIXct is honoured verbatim (in US/Eastern).
+  ts <- as.POSIXct("2026-07-21 06:30:00", tz = "US/Eastern")
+  out <- capture.output(
+    val_pkg_summary_line("cli", "3.6.1", "Low", elapsed_secs = 5,
+                         pkg_idx = 1, pkg_total = 10, timestamp = ts)
+  )
+  expect_match(out, "\\[06:30\\]")
+
+  # Character(1) passes through verbatim, letting callers pre-format if
+  # they want a different timezone.
+  out2 <- capture.output(
+    val_pkg_summary_line("cli", "3.6.1", "Low",
+                         timestamp = "12:34")
+  )
+  expect_match(out2, "\\[12:34\\]")
+
+  # NULL / non-POSIX defaults to Sys.time() in HH:MM.
+  out3 <- capture.output(
+    val_pkg_summary_line("cli", "3.6.1", "Low",
+                         timestamp = NULL)
+  )
+  expect_match(out3, "\\[\\d{2}:\\d{2}\\]")
 })
 
 


### PR DESCRIPTION
## What

Enhances the one-line-per-package summary emitted under `verbose = "minimal"` (and higher) so long `val_build()` runs are easier to follow at a glance.

## Before

```
   [Low]     dplyr v1.1.4                     (12s)
   [Medium]  ggplot2 v3.5.1                   (2m 18s)
   [Low]     zoo v1.8-12                      (3s)
```

## After

```
   [09:25] (   1/1195) [Low]     dplyr v1.1.4                     (12s)
   [09:25] (   2/1195) [Medium]  ggplot2 v3.5.1                   (2m 18s)
   ...
   [10:47] (1195/1195) [Low]     zoo v1.8-12                      (3s)
```

- Abbreviated `[HH:MM]` timestamp (US/Eastern), no seconds — enough to see when each package landed without cluttering the line.
- Right-aligned `(idx/total)` counter so values stay visually columnar across the entire run regardless of how wide the total is.

## How

- `val_pkg_summary_line()` gains three optional args — `pkg_idx`, `pkg_total`, `timestamp`. The counter block is omitted (rather than printing `(NA/NA)`) if either idx or total is missing. Timestamp defaults to `Sys.time()` in US/Eastern but accepts POSIXct or a pre-formatted character.
- `val_pkg()` accepts and forwards `pkg_idx` / `pkg_total` so callers driving iteration can pass the loop index in.
- `val_build()` threads the counter into all three summary-line call sites (cached-hit branch, dep-skip branch, and the normal `val_pkg()` path) so every code path renders identically.

## Compatibility

Fully backwards-compatible. Standalone `val_pkg()` calls (which don't know their position in a run) still render the timestamp and simply omit the counter block. All new args default to `NULL`.

## Tests

- Updated the existing format-check regex in `tests/testthat/test-verbosity.R` to tolerate the new leading `[HH:MM]` bracket.
- Added coverage for right-alignment across counter widths (`(   1/1195)` vs `(1195/1195)` vs `(3/7)`), partial-input omission behaviour, and POSIXct / character / NULL timestamp handling.
- Full suite: **494 pass / 0 fail** locally.