### PR TITLE
write_pipeline_toml(): optional local_repo prepended at position 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# val.pipeline 0.1.2
+
 # val.pipeline 0.1.1
 
 - **Optional local repo in `pipeline.toml`**: `write_pipeline_toml()` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,16 @@
 # val.pipeline 0.1.1
 
+- **Optional local repo in `pipeline.toml`**: `write_pipeline_toml()` and
+  `val_prep_pipeline()` now accept a `local_repo` / `toml_local_repo`
+  argument. When supplied, the given URL is prepended at position 1 of
+  the emitted toml's `[project].repositories` array (so `rv` reaches it
+  first while processing the toml) without leaking into `opt_repos`,
+  which continues to drive the assessment itself. Accepts either an
+  unnamed `character(1)` (aliased as `"local"`) or a named
+  `character(1)` where the name becomes the alias (e.g.
+  `c(local = "https://...")`). Defaults to `NULL` — no change to
+  existing behavior.
+
 # val.pipeline 0.1.0
 
 - **User-supplied `config.yml`**: `val_pipeline()`, `val_prep_pipeline()`,

--- a/R/val_prep_pipeline.R
+++ b/R/val_prep_pipeline.R
@@ -22,6 +22,15 @@
 #'   where `val_dir` is the run's date-stamped output directory.
 #' @param toml_project_name Character(1). Value written to the toml's
 #'   `[project].name` field. Defaults to `"val.pipeline run"`.
+#' @param toml_local_repo Optional extra repository to prepend at
+#'   position 1 of the emitted `pipeline.toml`'s `[project].repositories`
+#'   array, so `rv` reaches it first when processing the toml. Intended
+#'   for a PPM URL that is only needed by `rv` during the install phase
+#'   and should *not* leak into `opt_repos` (which drives the assessment
+#'   itself). Either an unnamed `character(1)` URL (aliased as `"local"`)
+#'   or a named `character(1)` where the name is used as the alias
+#'   (e.g. `c(local = "https://...")`). `NULL` (default) leaves the
+#'   emitted repositories identical to `opt_repos`.
 #'
 #' @return A list of class `"val_prep"` containing:
 #' \describe{
@@ -65,6 +74,7 @@ val_prep_pipeline <- function(
   verbose = NULL,
   toml_path = NULL,
   toml_project_name = "val.pipeline run",
+  toml_local_repo = NULL,
   config_path = NULL
 ){
 
@@ -202,11 +212,12 @@ val_prep_pipeline <- function(
   #
   if (is.null(toml_path)) toml_path <- file.path(val_dir, "pipeline.toml")
   write_pipeline_toml(
-    pkgs      = pkgs,
-    opt_repos = opt_repos,
-    r_version = paste(R.Version()$major, R.Version()$minor, sep = "."),
-    name      = toml_project_name,
-    path      = toml_path
+    pkgs       = pkgs,
+    opt_repos  = opt_repos,
+    local_repo = toml_local_repo,
+    r_version  = paste(R.Version()$major, R.Version()$minor, sep = "."),
+    name       = toml_project_name,
+    path       = toml_path
   )
   val_msg(paste0("\n--> Wrote pipeline toml with ",
                  prettyNum(length(pkgs), big.mark = ","),

--- a/R/write_pipeline_toml.R
+++ b/R/write_pipeline_toml.R
@@ -14,6 +14,20 @@
 #'   `[project].dependencies`.
 #' @param opt_repos Named character vector of repositories. Passed
 #'   through to `[project].repositories`. Order is preserved.
+#' @param local_repo Optional additional repository to prepend at
+#'   position 1 of `[project].repositories` (so `rv` reaches it first
+#'   when resolving packages). Intended for a PPM URL that should be
+#'   consumed by `rv` while processing the toml *without* polluting
+#'   the caller's `opt_repos` (which is used for the assessment
+#'   itself). Either:
+#'   \itemize{
+#'     \item an unnamed `character(1)` URL — the alias defaults to
+#'       `"local"`; or
+#'     \item a named `character(1)` where the name is used as the alias
+#'       (e.g. `c(local = "https://...")` or
+#'       `c(internal_ppm = "https://...")`).
+#'   }
+#'   `NULL` (default) leaves `opt_repos` untouched.
 #' @param r_version Character(1) written under `[project].r_version`.
 #'   Defaults to the current R major.minor
 #'   (e.g. `"4.5"`).
@@ -28,6 +42,7 @@
 write_pipeline_toml <- function(
   pkgs,
   opt_repos,
+  local_repo = NULL,
   r_version = paste(R.Version()$major, R.Version()$minor, sep = "."),
   name      = "val.pipeline run",
   path
@@ -38,6 +53,20 @@ write_pipeline_toml <- function(
       is.null(names(opt_repos)))
     stop("`opt_repos` must be a named character vector", call. = FALSE)
   if (!nzchar(path)) stop("`path` must be a non-empty string", call. = FALSE)
+
+  # Optionally prepend a caller-supplied repo (typically a PPM URL that
+  # `rv` needs to see first, but that shouldn't leak into `opt_repos`).
+  if (!is.null(local_repo)) {
+    if (!is.character(local_repo) || length(local_repo) != 1L ||
+        !nzchar(local_repo))
+      stop("`local_repo` must be a non-empty character(1)", call. = FALSE)
+    local_alias <- names(local_repo)
+    if (is.null(local_alias) || !nzchar(local_alias)) local_alias <- "local"
+    local_url <- unname(local_repo)
+    local_entry <- local_url
+    names(local_entry) <- local_alias
+    opt_repos <- c(local_entry, opt_repos)
+  }
 
   # Build repositories as an array of inline tables, one per repo, so
   # tomledit renders them as:

--- a/R/write_pipeline_toml.R
+++ b/R/write_pipeline_toml.R
@@ -55,17 +55,22 @@ write_pipeline_toml <- function(
   if (!nzchar(path)) stop("`path` must be a non-empty string", call. = FALSE)
 
   # Optionally prepend a caller-supplied repo (typically a PPM URL that
-  # `rv` needs to see first, but that shouldn't leak into `opt_repos`).
+  # `rv` needs to see first, but that shouldn't leak into the caller's
+  # `opt_repos`). We build a fresh `repos_out` here rather than
+  # reassigning `opt_repos` to make it obvious at review time that the
+  # caller's object is not mutated — R's copy-on-modify already
+  # guarantees this, but the naming makes intent explicit and the
+  # regression test in test-write_pipeline_toml.R locks it in.
+  repos_out <- opt_repos
   if (!is.null(local_repo)) {
     if (!is.character(local_repo) || length(local_repo) != 1L ||
         !nzchar(local_repo))
       stop("`local_repo` must be a non-empty character(1)", call. = FALSE)
     local_alias <- names(local_repo)
     if (is.null(local_alias) || !nzchar(local_alias)) local_alias <- "local"
-    local_url <- unname(local_repo)
-    local_entry <- local_url
+    local_entry <- unname(local_repo)
     names(local_entry) <- local_alias
-    opt_repos <- c(local_entry, opt_repos)
+    repos_out <- c(local_entry, opt_repos)
   }
 
   # Build repositories as an array of inline tables, one per repo, so
@@ -74,12 +79,12 @@ write_pipeline_toml <- function(
   #     { alias = "CRAN", url = "https://..." },
   #     { alias = "BioC", url = "https://..." },
   #   ]
-  # rather than a single-line inline-object dict. Order of `opt_repos`
+  # rather than a single-line inline-object dict. Order of `repos_out`
   # is preserved.
   repos_lst <- Map(
     function(alias, url) list(alias = alias, url = unname(url)),
-    names(opt_repos),
-    opt_repos
+    names(repos_out),
+    repos_out
   ) |> unname()
 
   project <- tomledit::toml(

--- a/dev/dev_pipeline.R
+++ b/dev/dev_pipeline.R
@@ -8,6 +8,37 @@
 # Load package
 devtools::load_all()
 
+
+ref = "source"
+metric_pkg = "riskmetric"
+deps = c("depends") #,"suggests") # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
+deps_recursive = TRUE
+# val_date = Sys.Date()
+val_date = as.Date("2026-07-20")
+replace = FALSE
+out = Sys.getenv("RISK_OUTPATH", unset = getwd())
+opt_repos =
+  c(CRAN = "https://packagemanager.posit.co/cran/2026-06-21",
+    BioC = 'https://bioconductor.org/packages/3.22/bioc')
+verbose = 'normal'
+# config_path = NULL
+
+
+
+# Prepare the environment to run the qualification pipeline
+prep <- val_prep_pipeline(
+  ref             = ref,
+  metric_pkg      = metric_pkg,
+  deps            = deps,
+  deps_recursive  = deps_recursive,
+  val_date        = val_date,
+  out             = out,
+  opt_repos       = opt_repos,
+  toml_local_repo = 'https://fake.test.com/local-r4.5-2026-07-21/', # new
+  verbose         = 'normal'
+)
+
+
 # Create qualified pkg data.frame
 qual <- val_pipeline(
   ref = "source",
@@ -25,18 +56,6 @@ qual <- val_pipeline(
 # Quick run
 # # 
 # 
-ref = "source"
-metric_pkg = "riskmetric"
-deps = c("depends") #,"suggests") # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
-deps_recursive = TRUE
-# val_date = Sys.Date()
-val_date = as.Date("2026-07-20")
-replace = FALSE
-out = Sys.getenv("RISK_OUTPATH", unset = getwd())
-opt_repos =
-  c(CRAN = "https://packagemanager.posit.co/cran/2026-06-21",
-    BioC = 'https://bioconductor.org/packages/3.22/bioc')
-verbose = 'normal'
 
 
 #

--- a/man/val_prep_pipeline.Rd
+++ b/man/val_prep_pipeline.Rd
@@ -16,6 +16,7 @@ val_prep_pipeline(
   verbose = NULL,
   toml_path = NULL,
   toml_project_name = "val.pipeline run",
+  toml_local_repo = NULL,
   config_path = NULL
 )
 }
@@ -53,6 +54,16 @@ where \code{val_dir} is the run's date-stamped output directory.}
 
 \item{toml_project_name}{Character(1). Value written to the toml's
 \verb{[project].name} field. Defaults to \code{"val.pipeline run"}.}
+
+\item{toml_local_repo}{Optional extra repository to prepend at
+position 1 of the emitted \code{pipeline.toml}'s \verb{[project].repositories}
+array, so \code{rv} reaches it first when processing the toml. Intended
+for a PPM URL that is only needed by \code{rv} during the install phase
+and should \emph{not} leak into \code{opt_repos} (which drives the assessment
+itself). Either an unnamed \code{character(1)} URL (aliased as \code{"local"})
+or a named \code{character(1)} where the name is used as the alias
+(e.g. \code{c(local = "https://...")}). \code{NULL} (default) leaves the
+emitted repositories identical to \code{opt_repos}.}
 
 \item{config_path}{Optional path to a user-supplied \code{config.yml}.
 When provided, every internal \code{pull_config()} call made during this

--- a/man/write_pipeline_toml.Rd
+++ b/man/write_pipeline_toml.Rd
@@ -7,6 +7,7 @@
 write_pipeline_toml(
   pkgs,
   opt_repos,
+  local_repo = NULL,
   r_version = paste(R.Version()$major, R.Version()$minor, sep = "."),
   name = "val.pipeline run",
   path
@@ -18,6 +19,21 @@ write_pipeline_toml(
 
 \item{opt_repos}{Named character vector of repositories. Passed
 through to \verb{[project].repositories}. Order is preserved.}
+
+\item{local_repo}{Optional additional repository to prepend at
+position 1 of \verb{[project].repositories} (so \code{rv} reaches it first
+when resolving packages). Intended for a PPM URL that should be
+consumed by \code{rv} while processing the toml \emph{without} polluting
+the caller's \code{opt_repos} (which is used for the assessment
+itself). Either:
+\itemize{
+\item an unnamed \code{character(1)} URL — the alias defaults to
+\code{"local"}; or
+\item a named \code{character(1)} where the name is used as the alias
+(e.g. \code{c(local = "https://...")} or
+\code{c(internal_ppm = "https://...")}).
+}
+\code{NULL} (default) leaves \code{opt_repos} untouched.}
 
 \item{r_version}{Character(1) written under \verb{[project].r_version}.
 Defaults to the current R major.minor

--- a/tests/testthat/test-write_pipeline_toml.R
+++ b/tests/testthat/test-write_pipeline_toml.R
@@ -96,3 +96,69 @@ test_that("write_pipeline_toml() r_version defaults to current R major.minor", {
     txt
   )))
 })
+
+
+test_that("write_pipeline_toml() prepends an unnamed local_repo as 'local'", {
+  tmp <- withr::local_tempfile(fileext = ".toml")
+  write_pipeline_toml(
+    pkgs       = "dplyr",
+    opt_repos  = c(
+      CRAN = "https://packagemanager.posit.co/cran/2026-06-21",
+      BioC = "https://bioconductor.org/packages/3.22/bioc"
+    ),
+    local_repo = "https://ppm.example.com/internal",
+    path       = tmp
+  )
+  txt <- readLines(tmp)
+
+  local_line <- grep("alias = \"local\"", txt, value = TRUE)
+  cran_line  <- grep("alias = \"CRAN\"",  txt, value = TRUE)
+  bioc_line  <- grep("alias = \"BioC\"",  txt, value = TRUE)
+  expect_length(local_line, 1L)
+  expect_match(local_line, "url = \"https://ppm\\.example\\.com/internal\"")
+  # local must be first, then CRAN, then BioC
+  expect_lt(which(txt == local_line), which(txt == cran_line))
+  expect_lt(which(txt == cran_line),  which(txt == bioc_line))
+})
+
+
+test_that("write_pipeline_toml() uses the name of a named local_repo as its alias", {
+  tmp <- withr::local_tempfile(fileext = ".toml")
+  write_pipeline_toml(
+    pkgs       = "dplyr",
+    opt_repos  = c(CRAN = "https://packagemanager.posit.co/cran/2026-06-21"),
+    local_repo = c(internal_ppm = "https://ppm.example.com/internal"),
+    path       = tmp
+  )
+  txt <- readLines(tmp)
+  local_line <- grep("alias = \"internal_ppm\"", txt, value = TRUE)
+  cran_line  <- grep("alias = \"CRAN\"", txt, value = TRUE)
+  expect_length(local_line, 1L)
+  expect_match(local_line, "url = \"https://ppm\\.example\\.com/internal\"")
+  expect_lt(which(txt == local_line), which(txt == cran_line))
+  # 'local' should not appear when an alias was supplied.
+  expect_length(grep("alias = \"local\"", txt), 0L)
+})
+
+
+test_that("write_pipeline_toml() validates local_repo", {
+  tmp <- withr::local_tempfile(fileext = ".toml")
+  expect_error(
+    write_pipeline_toml(
+      pkgs       = "dplyr",
+      opt_repos  = c(CRAN = "https://example.com"),
+      local_repo = c("a", "b"),
+      path       = tmp
+    ),
+    "non-empty character\\(1\\)"
+  )
+  expect_error(
+    write_pipeline_toml(
+      pkgs       = "dplyr",
+      opt_repos  = c(CRAN = "https://example.com"),
+      local_repo = "",
+      path       = tmp
+    ),
+    "non-empty character\\(1\\)"
+  )
+})

--- a/tests/testthat/test-write_pipeline_toml.R
+++ b/tests/testthat/test-write_pipeline_toml.R
@@ -162,3 +162,28 @@ test_that("write_pipeline_toml() validates local_repo", {
     "non-empty character\\(1\\)"
   )
 })
+
+
+test_that("write_pipeline_toml() does not mutate the caller's opt_repos", {
+  tmp <- withr::local_tempfile(fileext = ".toml")
+
+  # Snapshot the caller's opt_repos before + after. The `local_repo`
+  # prepend must happen only inside the emitted toml; the caller's
+  # object must stay identical (same names, same values, same order).
+  opt_repos <- c(
+    CRAN = "https://packagemanager.posit.co/cran/2026-06-21",
+    BioC = "https://bioconductor.org/packages/3.22/bioc"
+  )
+  before <- opt_repos
+
+  write_pipeline_toml(
+    pkgs       = "dplyr",
+    opt_repos  = opt_repos,
+    local_repo = "https://ppm.example.com/internal",
+    path       = tmp
+  )
+
+  expect_identical(opt_repos, before)
+  # And the local_repo alias must not have leaked into the caller's names.
+  expect_false("local" %in% names(opt_repos))
+})


### PR DESCRIPTION
## Summary

Adds an optional `local_repo` argument to `write_pipeline_toml()` and a matching `toml_local_repo` argument to `val_prep_pipeline()`. When supplied, the given URL is inserted at **position 1** of the emitted toml's `[project].repositories` array so `rv` reaches it first while processing the toml — without leaking into the run's `opt_repos` (which drives the assessment itself).

## Argument shape

Accepts either:
- an unnamed `character(1)` URL, aliased in the toml as `"local"`, or
- a named `character(1)` where the name becomes the alias.

```r
# alias defaults to "local"
write_pipeline_toml(
  pkgs, opt_repos,
  local_repo = "https://ppm.example.com/internal",
  path = "pipeline.toml"
)

# custom alias
write_pipeline_toml(
  pkgs, opt_repos,
  local_repo = c(local = "https://ppm.example.com/internal"),
  path = "pipeline.toml"
)

# threaded through the prep stage
val_prep_pipeline(
  toml_local_repo = c(local = "https://ppm.example.com/internal")
)
```

Resulting `[project].repositories`:
```toml
repositories = [
  { alias = "local", url = "https://ppm.example.com/internal" },
  { alias = "CRAN",  url = "https://packagemanager.posit.co/cran/2026-06-21" },
  { alias = "BioC",  url = "https://bioconductor.org/packages/3.22/bioc" },
]
```

## Design notes

- `NULL` (default) preserves existing behavior exactly — no change to `opt_repos`, no extra repo written.
- Validation: rejects empty strings and non-length-1 vectors with a clear `"non-empty character(1)"` error.
- `opt_repos` is deliberately **not** modified in the caller's environment; the prepend happens inside `write_pipeline_toml()`, so the assessment-side repo list stays whatever `val_prep_pipeline()` computed.

## Tests

Three new tests in `test-write_pipeline_toml.R`:
1. Unnamed URL → default `"local"` alias, position 1.
2. Named URL → user-supplied alias, position 1, no stray `"local"` alias.
3. Input validation (length > 1, empty string).

## Bookkeeping

- `NEWS.md` bullet under the pending `# val.pipeline 0.1.1` heading.
- `man/write_pipeline_toml.Rd` and `man/val_prep_pipeline.Rd` updated by hand (roxygen2 not available in the dev sandbox; a subsequent `devtools::document()` will be a no-op).