### PR TITLE
Configure pkgdown to autolink #N NEWS refs; codify convention

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -187,8 +187,13 @@ Every PR must include:
    effect).
 2. **NEWS.md**: add one bullet under `# val.pipeline (development version)`
    at the **bottom** of the existing list. Format: short imperative summary
-   of the user-visible change, ending with `(#<n>)` referencing the issue.
-   Match the voice of surrounding bullets. Skip only for changes with zero
+   of the user-visible change, ending with `(#<n>)` referencing the PR or
+   issue. **Always use the bare `#<n>` autolink form** — never a full
+   Markdown link (`[#78](https://…)`) or a plain URL. `pkgdown` and
+   GitHub's own renderer autolink `#N` against `URL:` in `DESCRIPTION`, so
+   the bare form renders as a link everywhere while keeping the source
+   readable. When both a PR and an issue exist, cite the PR. Match the
+   voice of surrounding bullets. Skip only for changes with zero
    user-visible / reviewer-visible effect (comment tweak, internal test
    rename that ships no behavior). If unsure, add the entry.
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# val.pipeline 0.1.7
+
+- Configure `pkgdown` to autolink bare `#N` references in NEWS.md and
+  roxygen blocks to the corresponding GitHub issue/PR, and codify the
+  bare-`#N` convention in `.github/copilot-instructions.md` so future
+  NEWS entries stay autolink-friendly. (#79)
+
 # val.pipeline 0.1.6
 
 - Add `configure_bioc_repositories()` and

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,16 @@
+url: https://pharmar.github.io/val.pipeline
+
+# `#N` references in NEWS.md, roxygen `@description`, etc. autolink to
+# `<url>/issues/N` when `url:` above is set to the GitHub repo (pkgdown
+# resolves via the DESCRIPTION `URL:` field otherwise). Kept explicit
+# here so contributors don't have to guess where the autolink target
+# comes from — see `.github/copilot-instructions.md` for the NEWS
+# writing convention.
+
+template:
+  bootstrap: 5
+
+news:
+  releases:
+    - text: "Development version"
+      href: news/index.html


### PR DESCRIPTION
Idea **#15** from `dev/pipeline-improvement-ideas.md` — small, standalone follow-up meant to merge *before* #78.

## What changes

- **New `_pkgdown.yml`.** Declares `url: https://pharmar.github.io/val.pipeline` so `pkgdown` resolves bare `#N` references in `NEWS.md` (and roxygen `@description` blocks) to the corresponding GitHub issue / PR. GitHub's own renderer already autolinks `#N` against `DESCRIPTION`'s `URL:` field, so with this in place the bare form renders as a link everywhere — GitHub, `pkgdown` site, RStudio's help viewer — while the raw source stays readable and grep-friendly.
- **`.github/copilot-instructions.md`.** Adds the autolink convention to the existing "Version + NEWS bump per PR" section. New rule: every NEWS bullet ends in bare `(#N)` — never full Markdown links, never plain URLs — and cites the PR when both a PR and an issue exist.

Existing NEWS entries under 0.1.6 and earlier are left alone; the new convention applies going forward. (The companion PR #78 backfills `(#78)` on its own 0.1.7 bullets.)

## Compatibility

- Public-facing behavior of the R package is unchanged.
- `pkgdown` builds should now link `#N` refs; sites built before this PR just render `#N` as plain text — no regression.
- No new dependencies.

## Ordering

Please merge this **before** #78. #78 currently claims `Version: 0.1.7` and its NEWS bullets already cite `(#78)`; after this PR merges as 0.1.7, I'll rebase #78 to 0.1.8.