### PR TITLE
Shim riskmetric:::memoise_bioc_available for air-gapped BioC lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .Ruserdata
 .Renviron
 dev/riskassessments/*
+dev/riskmetric-bioc-available-shim.txt
 
 # testthat scratch directories: some upstream packages' test suites
 # copy themselves into <pkg>-tests/ dirs at the repo root when they

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .Renviron
 dev/riskassessments/*
 dev/riskmetric-bioc-available-shim.txt
+dev/air-gapped-bioc-mirror-config.txt
 
 # testthat scratch directories: some upstream packages' test suites
 # copy themselves into <pkg>-tests/ dirs at the repo root when they

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.10
+Version: 0.1.7
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.6
+Version: 0.1.10
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.7
+Version: 0.1.8
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,17 +1,21 @@
 # val.pipeline 0.1.7
 
-- `configure_riskmetric_offline()` now installs a second in-session
-  shim on `riskmetric:::memoise_bioc_available`, replacing its
-  hard-coded `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
-  lookup with a `utils::available.packages()` call against every
-  `BioC*` repo advertised by `BiocManager::repositories()`. Fixes
-  `pkg_ref("<BioCPkg>")` failing on air-gapped hosts with
-  `cannot open the connection to
-  'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'`
-  even after `configure_bioc_repositories()` had already re-pointed
-  BiocManager at the internal mirrors — that URL is contacted
-  directly, bypassing `BiocManager::repositories()`. Upstream fix
-  proposed at `pharmaR/riskmetric#402`. (#81)
+- `configure_riskmetric_offline()` now installs three in-session shims
+  on `riskmetric` (was two). Shim 2 continues to replace
+  `riskmetric:::memoise_bioc_available()`'s hard-coded
+  `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
+  lookup with a `utils::available.packages()` call; its BioC-repo
+  resolver is now flexible enough to handle consolidated PPM setups
+  where one URL serves both CRAN and Bioconductor snapshots. Callers
+  can override detection explicitly via
+  `options(val.pipeline.bioc_repos = ...)` or
+  `Sys.setenv(VAL_PIPELINE_BIOC_REPOS = "<comma-separated URLs>")`.
+  A new Shim 3 wraps `riskmetric:::is_available_cran()` so that a
+  package which is also present in `memoise_bioc_available()` no
+  longer wins the CRAN check, restoring `pkg_bioc_remote`
+  classification for BioC packages served from a shared repo (fixes
+  `pkg_ref("BiocGenerics")` being classified as `pkg_cran_remote`).
+  Upstream fix proposed at `pharmaR/riskmetric#402`. (#81)
 
 # val.pipeline 0.1.6
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# val.pipeline 0.1.10
+# val.pipeline 0.1.7
 
 - `configure_riskmetric_offline()` now installs a second in-session
   shim on `riskmetric:::memoise_bioc_available`, replacing its

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# val.pipeline 0.1.10
+
+- `configure_riskmetric_offline()` now installs a second in-session
+  shim on `riskmetric:::memoise_bioc_available`, replacing its
+  hard-coded `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
+  lookup with a `utils::available.packages()` call against every
+  `BioC*` repo advertised by `BiocManager::repositories()`. Fixes
+  `pkg_ref("<BioCPkg>")` failing on air-gapped hosts with
+  `cannot open the connection to
+  'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'`
+  even after `configure_bioc_repositories()` had already re-pointed
+  BiocManager at the internal mirrors — that URL is contacted
+  directly, bypassing `BiocManager::repositories()`. Upstream fix
+  proposed at `pharmaR/riskmetric#402`. (#81)
+
 # val.pipeline 0.1.6
 
 - Add `configure_bioc_repositories()` and

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# val.pipeline 0.1.7
+# val.pipeline 0.1.8
 
 - `configure_riskmetric_offline()` now installs four in-session shims
   on `riskmetric` to make BioC assessments work on air-gapped hosts,
@@ -35,6 +35,9 @@
     `Failed to connect to bioconductor.org port 443: Connection refused`
     because they scrape `x$web_html` derived from `x$repo_base_url`.
   (#81)
+
+# val.pipeline 0.1.7
+
 - `val_pkg()` now prefers a disk-only reference for the initial
   assessment of Bioconductor packages instead of scraping
   `bioconductor.org` via `pkg_bioc_remote`. On air-gapped Posit

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,21 +1,40 @@
 # val.pipeline 0.1.7
 
-- `configure_riskmetric_offline()` now installs three in-session shims
-  on `riskmetric` (was two). Shim 2 continues to replace
-  `riskmetric:::memoise_bioc_available()`'s hard-coded
-  `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
-  lookup with a `utils::available.packages()` call; its BioC-repo
-  resolver is now flexible enough to handle consolidated PPM setups
-  where one URL serves both CRAN and Bioconductor snapshots. Callers
-  can override detection explicitly via
-  `options(val.pipeline.bioc_repos = ...)` or
-  `Sys.setenv(VAL_PIPELINE_BIOC_REPOS = "<comma-separated URLs>")`.
-  A new Shim 3 wraps `riskmetric:::is_available_cran()` so that a
-  package which is also present in `memoise_bioc_available()` no
-  longer wins the CRAN check, restoring `pkg_bioc_remote`
-  classification for BioC packages served from a shared repo (fixes
-  `pkg_ref("BiocGenerics")` being classified as `pkg_cran_remote`).
-  Upstream fix proposed at `pharmaR/riskmetric#402`. (#81)
+- `configure_riskmetric_offline()` now installs four in-session shims
+  on `riskmetric` to make BioC assessments work on air-gapped hosts,
+  replacing the two shims previously introduced in this branch.
+  Upstream fix proposed at `pharmaR/riskmetric#402`.
+  - Shim 1 (unchanged): swaps
+    `riskmetric:::assess_reverse_dependencies.default()` for a version
+    that computes reverse dependencies via `utils::available.packages()`
+    + `tools::dependsOnPkgs()` instead of
+    `devtools::revdep(bioconductor = TRUE)` (which reads a `VIEWS`
+    file the internal PPM does not serve).
+  - Shim 2 replaces `riskmetric:::memoise_bioc_available()`'s
+    hard-coded
+    `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
+    lookup with a `utils::available.packages()` call. The BioC-repo
+    resolver now handles setups where the BioC PPM is exposed via
+    `options("repos")` without a `BioC*` name; callers can also
+    override detection explicitly via
+    `options(val.pipeline.bioc_repos = ...)` or
+    `Sys.setenv(VAL_PIPELINE_BIOC_REPOS = "<comma-separated URLs>")`.
+  - Shim 3 wraps `riskmetric:::is_available_cran()` so a package that
+    is also present in `memoise_bioc_available()` no longer wins the
+    CRAN check, restoring `pkg_bioc_remote` classification for BioC
+    packages served alongside CRAN in `options("repos")` (fixes
+    `pkg_ref("BiocGenerics")` being classified as `pkg_cran_remote`).
+  - Shim 4 replaces `riskmetric:::pkg_bioc()` so the resulting
+    `pkg_bioc_remote` reference carries the internal PPM BioC URL in
+    `x$repo` / `x$repo_base_url` instead of the released code's
+    hard-coded `https://bioconductor.org/packages/release/bioc`.
+    Fixes a family of `pkg_assess()` metrics (`has_news`,
+    `remote_checks`, `news_current`, `has_vignettes`, `has_maintainer`,
+    `bugs_status`, `has_source_control`, `has_bug_reports_url`,
+    `license`, ...) failing with
+    `Failed to connect to bioconductor.org port 443: Connection refused`
+    because they scrape `x$web_html` derived from `x$repo_base_url`.
+  (#81)
 
 # val.pipeline 0.1.6
 

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -179,7 +179,7 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 
 #' Route `riskmetric`'s Bioconductor lookups through internal repos
 #'
-#' Installs three in-session shims on `riskmetric` so its Bioconductor-facing
+#' Installs four in-session shims on `riskmetric` so its Bioconductor-facing
 #' code paths stop reaching out to public `bioconductor.org` URLs and
 #' instead consult `options("repos")` — i.e. the same internal PPM CRAN
 #' and BioC snapshots the rest of `val.pipeline` uses.
@@ -251,7 +251,29 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 #' falls through to `is_available_bioc()`. `pkg_ref("BiocGenerics")`
 #' then correctly returns a `pkg_bioc_remote`.
 #'
-#' All three shims are intentionally opt-in; the wrapper
+#' # Shim 4: `pkg_bioc`
+#'
+#' Released `riskmetric::pkg_bioc()` builds the `pkg_bioc_remote`
+#' reference with a hard-coded
+#' `repo = "https://bioconductor.org/packages/release/bioc"`, discarding
+#' the `Repository` column returned by `memoise_bioc_available()`. Every
+#' downstream metric that follows `x$repo_base_url` — `has_news`,
+#' `remote_checks`, `news_current`, `has_vignettes`, `has_maintainer`,
+#' `bugs_status`, `has_source_control`, `has_bug_reports_url`, `license`,
+#' and friends — then fetches from `bioconductor.org` and fails with
+#'
+#' \preformatted{
+#' Failed to connect to bioconductor.org port 443: Connection refused
+#' }
+#'
+#' on air-gapped hosts. The shim replaces `pkg_bioc()` with a version
+#' that uses the `Repository` column from the shimmed
+#' `memoise_bioc_available()` (i.e. the internal PPM BioC URL), so
+#' `x$repo_base_url` points at the mirror and every derived scrape hits
+#' the mirror too. Mirrors the upstream fix at
+#' \href{https://github.com/pharmaR/riskmetric/pull/402}{pharmaR/riskmetric#402}.
+#'
+#' All four shims are intentionally opt-in; the wrapper
 #' [configure_riskmetric_offline_if_requested()] runs this helper only
 #' when the run is flagged as air-gapped (env var
 #' `VAL_PIPELINE_INTERNAL_BIOC` truthy, or `default: air_gapped: true`
@@ -420,6 +442,45 @@ configure_riskmetric_offline <- function(quiet = FALSE) {
     utils::assignInNamespace(
       "is_available_cran", is_available_cran_shim, ns = "riskmetric"
     )
+  }
+
+  # Shim 4: released riskmetric's pkg_bioc() hard-codes
+  #   repo = "https://bioconductor.org/packages/release/bioc"
+  # ignoring the Repository column from memoise_bioc_available(). Every
+  # downstream metric that scrapes x$web_html then derives its URL from
+  # bioconductor.org and fails on air-gapped hosts with
+  #   Failed to connect to bioconductor.org port 443: Connection refused
+  # (has_news, remote_checks, news_current, has_vignettes, has_maintainer,
+  # bugs_status, has_source_control, has_bug_reports_url, license, ...).
+  # Replace pkg_bioc() with a version that uses the Repository column
+  # from our shimmed memoise_bioc_available() -- i.e. the internal PPM
+  # BioC URL -- and falls back to the first repo returned by
+  # bioc_repos_from_config() when the pkg is unknown. Mirrors the fix
+  # upstream at pharmaR/riskmetric#402.
+  new_pkg_ref_fn <- tryCatch(
+    getFromNamespace("new_pkg_ref", ns = "riskmetric"),
+    error = function(e) NULL
+  )
+  if (!is.null(new_pkg_ref_fn)) {
+    pkg_bioc_offline <- function(x) {
+      bp <- getFromNamespace("memoise_bioc_available", ns = "riskmetric")()
+      info <- bp[bp[, "Package"] == x, , drop = FALSE]
+      repo <- if ("Repository" %in% colnames(info) && nrow(info) > 0L) {
+        sub("/src/contrib$", "", info[, "Repository"][1])
+      } else {
+        fallback <- bioc_repos_from_config()
+        if (length(fallback)) unname(fallback[1]) else
+          "https://bioconductor.org/packages/release/bioc"
+      }
+      version <- if (nrow(info) > 0L) info[, "Version"] else NA_character_
+      new_pkg_ref_fn(
+        x,
+        version = version,
+        repo    = repo,
+        source  = c("pkg_bioc_remote")
+      )
+    }
+    utils::assignInNamespace("pkg_bioc", pkg_bioc_offline, ns = "riskmetric")
   }
 
   if (!isTRUE(quiet)) {

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -177,7 +177,14 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 }
 
 
-#' Route `riskmetric::assess_reverse_dependencies()` through internal repos
+#' Route `riskmetric`'s Bioconductor lookups through internal repos
+#'
+#' Installs two in-session shims on `riskmetric` so its Bioconductor-facing
+#' code paths stop reaching out to public `bioconductor.org` URLs and
+#' instead consult `options("repos")` — i.e. the same internal PPM CRAN
+#' and BioC snapshots the rest of `val.pipeline` uses.
+#'
+#' # Shim 1: `assess_reverse_dependencies.default`
 #'
 #' `riskmetric::assess_reverse_dependencies.default()` calls
 #' `devtools::revdep(x$name, bioconductor = TRUE)`, which in turn calls
@@ -191,19 +198,36 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 #' cannot open the connection to '.../bioc-.../latest/VIEWS'
 #' }
 #'
-#' and the reverse-dependencies metric ends up as a `pkg_metric_error`
-#' (which the package report renders as `"unknown"`).
+#' The shim replaces it with a version that computes reverse
+#' dependencies from `utils::available.packages()` +
+#' `tools::dependsOnPkgs()`. No `VIEWS` file is required.
 #'
-#' This helper installs an in-session shim on
-#' `riskmetric:::assess_reverse_dependencies.default` that computes the
-#' reverse-dependency list from `utils::available.packages()` directly
-#' (which reads from `options("repos")` — i.e. the internal PPM CRAN
-#' and BioC snapshots). No `VIEWS` file is required.
+#' # Shim 2: `memoise_bioc_available`
 #'
-#' The shim is intentionally opt-in; the wrapper
-#' [configure_riskmetric_offline_if_requested()] runs it only when the
-#' environment variable `VAL_PIPELINE_INTERNAL_BIOC` is truthy, so
-#' public-network users are unaffected.
+#' `riskmetric:::memoise_bioc_available()` hard-codes
+#' `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`
+#' to build its Bioconductor package index. That URL is contacted
+#' *directly*, bypassing `BiocManager::repositories()`, so
+#' [configure_bioc_repositories()] alone can't rescue it and
+#' `pkg_ref("<BioCPkg>")` fails on an air-gapped host with
+#'
+#' \preformatted{
+#' cannot open the connection to 'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'
+#' }
+#'
+#' The shim replaces it with a version that queries every `BioC*` repo
+#' advertised by `BiocManager::repositories()` (which
+#' [configure_bioc_repositories()] has already pointed at the internal
+#' mirrors) via `utils::available.packages()`. The result is memoised
+#' with `memoise::memoise()`, matching the upstream contract, so
+#' repeated `pkg_ref()` calls hit the cache. Upstream fix proposed at
+#' \href{https://github.com/pharmaR/riskmetric/pull/402}{pharmaR/riskmetric#402}.
+#'
+#' Both shims are intentionally opt-in; the wrapper
+#' [configure_riskmetric_offline_if_requested()] runs this helper only
+#' when the run is flagged as air-gapped (env var
+#' `VAL_PIPELINE_INTERNAL_BIOC` truthy, or `default: air_gapped: true`
+#' in `config.yml`), so public-network users are unaffected.
 #'
 #' @param quiet Logical. When `FALSE` (the default) a short informational
 #'   message is emitted.
@@ -254,11 +278,61 @@ configure_riskmetric_offline <- function(quiet = FALSE) {
     ns = "riskmetric"
   )
 
+  # riskmetric's memoise_bioc_available() hard-codes a read.dcf() against
+  #   https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES
+  # (see pharmaR/riskmetric R/utils_memoised.R line ~39). It's called by
+  # riskmetric::pkg_bioc() / pkg_ref() to look up a BioC package's
+  # version + repo. On an air-gapped host the read fails with
+  #   Error in read.dcf(con): cannot open the connection to
+  #   'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'
+  # even after configure_bioc_repositories() has repointed BiocManager at
+  # the internal repos, because this call bypasses BiocManager entirely.
+  #
+  # Replace it with a version that queries every BioC* repo advertised by
+  # BiocManager::repositories() via utils::available.packages(), which
+  # reads options("repos"). No public bioconductor.org URL is contacted.
+  # Upstream fix proposed at pharmaR/riskmetric#402.
+  bioc_available_offline <- function() {
+    repos <- tryCatch(BiocManager::repositories(), error = function(e) NULL)
+    bioc_repos <- if (!is.null(repos)) {
+      nms <- names(repos)
+      if (is.null(nms)) character(0) else repos[startsWith(nms, "BioC")]
+    } else character(0)
+    if (length(bioc_repos) == 0L) bioc_repos <- getOption("repos")
+
+    ap <- tryCatch(
+      utils::available.packages(repos = bioc_repos),
+      error = function(e) NULL
+    )
+    if (is.null(ap) || nrow(ap) == 0L) {
+      return(data.frame(
+        Package = character(0), Version = character(0),
+        Repository = character(0), stringsAsFactors = FALSE))
+    }
+    df <- as.data.frame(ap, stringsAsFactors = FALSE)
+    df[!duplicated(df[["Package"]]), , drop = FALSE]
+  }
+  # memoise the offline function the same way riskmetric memoised the
+  # original so repeated pkg_ref() calls hit the cache after the first
+  # query and don't re-shell to available.packages().
+  memoised_offline <- if (requireNamespace("memoise", quietly = TRUE)) {
+    memoise::memoise(bioc_available_offline)
+  } else {
+    bioc_available_offline
+  }
+  utils::assignInNamespace(
+    "memoise_bioc_available",
+    memoised_offline,
+    ns = "riskmetric"
+  )
+
   if (!isTRUE(quiet)) {
     message(
       "configure_riskmetric_offline(): riskmetric's reverse-dependency ",
-      "lookup will now use utils::available.packages() (options(\"repos\")) ",
-      "instead of devtools::revdep(bioconductor = TRUE)."
+      "lookup and Bioconductor package index will now use ",
+      "utils::available.packages() (options(\"repos\")) instead of ",
+      "devtools::revdep(bioconductor = TRUE) and a hard-coded ",
+      "bioconductor.org/packages/release/bioc URL."
     )
   }
 

--- a/R/bioc.R
+++ b/R/bioc.R
@@ -179,7 +179,7 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 
 #' Route `riskmetric`'s Bioconductor lookups through internal repos
 #'
-#' Installs two in-session shims on `riskmetric` so its Bioconductor-facing
+#' Installs three in-session shims on `riskmetric` so its Bioconductor-facing
 #' code paths stop reaching out to public `bioconductor.org` URLs and
 #' instead consult `options("repos")` — i.e. the same internal PPM CRAN
 #' and BioC snapshots the rest of `val.pipeline` uses.
@@ -215,15 +215,43 @@ configure_bioc_repositories_if_requested <- function(quiet = FALSE) {
 #' cannot open the connection to 'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'
 #' }
 #'
-#' The shim replaces it with a version that queries every `BioC*` repo
-#' advertised by `BiocManager::repositories()` (which
-#' [configure_bioc_repositories()] has already pointed at the internal
-#' mirrors) via `utils::available.packages()`. The result is memoised
-#' with `memoise::memoise()`, matching the upstream contract, so
-#' repeated `pkg_ref()` calls hit the cache. Upstream fix proposed at
+#' The shim replaces it with a version that queries the set of
+#' Bioconductor repos advertised to the session and passes them to
+#' `utils::available.packages()`. That set is resolved, in order of
+#' specificity, from:
+#'
+#' \enumerate{
+#'   \item `options("val.pipeline.bioc_repos")` — explicit override
+#'     (named `character` or single URL);
+#'   \item `Sys.getenv("VAL_PIPELINE_BIOC_REPOS")` — comma-separated URLs;
+#'   \item `BiocManager::repositories()` entries whose names begin `BioC`;
+#'   \item `options("repos")` entries whose name begins `BioC` *or*
+#'     whose URL contains `bioconductor` / `/bioc/` (case-insensitive);
+#'   \item `options("repos")` in full, as a last resort.
+#' }
+#'
+#' Step 4 lets consolidated PPM setups — where one URL serves both CRAN
+#' and BioC snapshots — work without having to synthesise five fake
+#' `BioC*` entries. The result is memoised with `memoise::memoise()`,
+#' matching the upstream contract, so repeated `pkg_ref()` calls hit
+#' the cache. Upstream fix proposed at
 #' \href{https://github.com/pharmaR/riskmetric/pull/402}{pharmaR/riskmetric#402}.
 #'
-#' Both shims are intentionally opt-in; the wrapper
+#' # Shim 3: `is_available_cran`
+#'
+#' `riskmetric:::verify_pkg_source()` calls `is_available_cran()` before
+#' `is_available_bioc()`. When one consolidated PPM repo advertises both
+#' CRAN and Bioconductor packages, BioC packages such as `BiocGenerics`
+#' are found by the CRAN check first and classified as `pkg_cran_remote`
+#' — which then breaks Bioconductor-specific downstream code (for
+#' example the `has_examples` metric has no `pkg_cran_remote` method,
+#' and reverse-dependency lookups follow the wrong code path). The shim
+#' wraps `is_available_cran` so any package that is also present in
+#' `memoise_bioc_available()` no longer counts as CRAN, and dispatch
+#' falls through to `is_available_bioc()`. `pkg_ref("BiocGenerics")`
+#' then correctly returns a `pkg_bioc_remote`.
+#'
+#' All three shims are intentionally opt-in; the wrapper
 #' [configure_riskmetric_offline_if_requested()] runs this helper only
 #' when the run is flagged as air-gapped (env var
 #' `VAL_PIPELINE_INTERNAL_BIOC` truthy, or `default: air_gapped: true`
@@ -292,14 +320,50 @@ configure_riskmetric_offline <- function(quiet = FALSE) {
   # BiocManager::repositories() via utils::available.packages(), which
   # reads options("repos"). No public bioconductor.org URL is contacted.
   # Upstream fix proposed at pharmaR/riskmetric#402.
-  bioc_available_offline <- function() {
+  # Detect the set of Bioconductor repositories to query.
+  # Users on air-gapped hosts often have a *single consolidated* BioC PPM
+  # repo rather than the five named entries (BioCsoft/BioCann/...) that
+  # BiocManager::repositories() returns on the public network — so we
+  # look in several places, in order of specificity:
+  #   1. options("val.pipeline.bioc_repos") — explicit override.
+  #   2. Sys.getenv("VAL_PIPELINE_BIOC_REPOS") — comma-separated URLs.
+  #   3. BiocManager::repositories() entries whose names start "BioC".
+  #   4. options("repos") entries whose name starts "BioC" *or* whose
+  #      URL contains "bioconductor" / "/bioc/" (case-insensitive).
+  #   5. As a last resort, options("repos") in full — honest but noisy.
+  bioc_repos_from_config <- function() {
+    opt <- getOption("val.pipeline.bioc_repos", NULL)
+    if (length(opt)) return(opt)
+    env <- Sys.getenv("VAL_PIPELINE_BIOC_REPOS", unset = "")
+    if (nzchar(env)) return(trimws(strsplit(env, ",", fixed = TRUE)[[1]]))
     repos <- tryCatch(BiocManager::repositories(), error = function(e) NULL)
-    bioc_repos <- if (!is.null(repos)) {
+    if (length(repos)) {
       nms <- names(repos)
-      if (is.null(nms)) character(0) else repos[startsWith(nms, "BioC")]
-    } else character(0)
-    if (length(bioc_repos) == 0L) bioc_repos <- getOption("repos")
-
+      if (!is.null(nms)) {
+        hits <- repos[startsWith(nms, "BioC")]
+        if (length(hits)) return(hits)
+      }
+    }
+    all_repos <- getOption("repos", character())
+    if (length(all_repos)) {
+      nms <- names(all_repos)
+      if (is.null(nms)) nms <- rep("", length(all_repos))
+      match_name <- startsWith(nms, "BioC")
+      match_url  <- grepl("bioconductor|/bioc(/|$)",
+                          all_repos, ignore.case = TRUE)
+      hits <- all_repos[match_name | match_url]
+      if (length(hits)) return(hits)
+      return(all_repos)
+    }
+    character()
+  }
+  bioc_available_offline <- function() {
+    bioc_repos <- bioc_repos_from_config()
+    if (length(bioc_repos) == 0L) {
+      return(data.frame(
+        Package = character(0), Version = character(0),
+        Repository = character(0), stringsAsFactors = FALSE))
+    }
     ap <- tryCatch(
       utils::available.packages(repos = bioc_repos),
       error = function(e) NULL
@@ -325,6 +389,38 @@ configure_riskmetric_offline <- function(quiet = FALSE) {
     memoised_offline,
     ns = "riskmetric"
   )
+
+  # Shim 3: riskmetric:::is_available_cran() runs *before*
+  # is_available_bioc() in pkg_ref() dispatch. When the caller's PPM
+  # serves both CRAN and BioC packages under a single consolidated repo
+  # (or when the BioC PPM is exposed via options("repos") without a
+  # BioC* name), a BioC package like BiocGenerics is found by
+  # available.packages() first and classified as "pkg_cran_remote".
+  # That in turn breaks BioC-only assessments (has_examples has no
+  # pkg_cran_remote method; reverse_dependencies hits the wrong URL).
+  #
+  # Wrap is_available_cran so a package that is *also* in
+  # memoise_bioc_available() no longer counts as CRAN; classification
+  # falls through to is_available_bioc(), and the ref becomes a
+  # pkg_bioc_remote as intended.
+  is_available_cran_orig <- tryCatch(
+    getFromNamespace("is_available_cran", ns = "riskmetric"),
+    error = function(e) NULL
+  )
+  if (!is.null(is_available_cran_orig)) {
+    is_available_cran_shim <- function(x, repos, p) {
+      in_bioc <- tryCatch(
+        x %in% getFromNamespace("memoise_bioc_available",
+                                ns = "riskmetric")()[, "Package"],
+        error = function(e) FALSE
+      )
+      if (isTRUE(in_bioc)) return(FALSE)
+      is_available_cran_orig(x, repos, p)
+    }
+    utils::assignInNamespace(
+      "is_available_cran", is_available_cran_shim, ns = "riskmetric"
+    )
+  }
 
   if (!isTRUE(quiet)) {
     message(

--- a/dev/dev_build.R
+++ b/dev/dev_build.R
@@ -31,8 +31,19 @@ pkgs[!pkgs %in% report_pkgs]
 # qual <- readRDS(file.path(val_dir, paste0("qual_evidence_", val_date_txt, ".rds")))
 
 
-
-
+Sys.setenv(R_BIOC_VERSION = "3.22")
+options(BioCManager.check_repositories = FALSE)
+configure_bioc_repositories_if_requested(quiet = TRUE)
+configure_riskmetric_offline_if_requested(quiet = TRUE)
+assess_metrics <- riskmetric::all_assessments()
+p <- riskmetric::pkg_ref("BiocGenerics")
+riskmetric::assess_has_examples(p)
+bg_assess <- p |> 
+  dplyr::as_tibble() |>
+  riskmetric::pkg_assess(p)
+bg_assess |>
+  dplyr::as_tibble() |>
+  t()
 
 # Create qualified pkg data.frame
 # source("dev/pkg_lists.R") # build_pkgs & pkgs for CRAN only

--- a/dev/pipeline-improvement-ideas.md
+++ b/dev/pipeline-improvement-ideas.md
@@ -1,0 +1,143 @@
+# val.pipeline — Improvement Ideas
+
+Compiled 2026-07-29. Ordered by rough impact; the last section is a
+suggested pick-3 if you only want to tackle a few.
+
+---
+
+## High-impact
+
+1. **Config validation + versioning.**
+   `pull_config()` returns whatever YAML you feed it; a typo in a key
+   (e.g. `weight` vs `weights`) silently falls back to defaults. Ship a
+   JSON Schema (or `config::validate()` shim) that runs at
+   `val_pipeline()` start and errors early with the offending key.
+   Add a `config_version:` field so old configs are rejected/migrated
+   instead of half-working.
+
+2. **Fully resumable runs.**
+   `val_build()` is the expensive step. You already cache per-package
+   assessments to `<val_dir>/assessments/<pkg>.rds`. Add a `resume=TRUE`
+   flag that skips packages whose rds already exists (guarded by a
+   checksum of inputs). Combined with the BioC shim, this lets air-gapped
+   users iterate without paying full cost.
+
+3. **Structured logging + a single `run.log`.**
+   Verbosity tiers control console output; also write every phase
+   (`prep_start`, `prep_end`, `build_start`, per-pkg start/end, timings,
+   warnings) as JSON lines into `<val_dir>/run.log`. Makes post-mortems
+   and CI dashboards straightforward. Bonus: surface total wall-clock
+   per phase in the final report.
+
+4. **Parallelism for `val_build()`.**
+   Package assessments are embarrassingly parallel. Wrap the main loop
+   in `future.apply::future_lapply()` with a `workers=` param (default 1
+   for reproducibility). On a 32-pkg run this is a real difference.
+
+5. **Deterministic snapshot manifest.**
+   Emit `manifest.json` alongside `pipeline.toml` capturing: R version,
+   riskmetric/val.pipeline versions, `opt_repos` with resolved snapshot
+   dates, config hash, package SHAs. That single file makes a report
+   reproducible on demand.
+
+---
+
+## Medium-impact
+
+6. **Retry + backoff for network ops.**
+   `available.packages()` / `install.packages()` failures during PPM
+   hiccups tank a whole run. Wrap network entry points in a small
+   `.with_retry()` helper (3 tries, exponential backoff, respect
+   `Retry-After`).
+
+7. **Per-package timeout.**
+   A hanging `R CMD check` or `covr` on one package can wedge the
+   pipeline. `R.utils::withTimeout()` with per-metric budgets from
+   config, and record `"timed_out"` as the metric value.
+
+8. **`dry_run = TRUE`.**
+   Have `val_pipeline()` accept a flag that runs prep + prints the
+   resolved package list, `opt_repos`, config, and estimated run size
+   (deps count) without building. Great for reviewers before a big run.
+
+9. **Bundle the shim opt-in into config.**
+   Instead of `Sys.setenv(VAL_PIPELINE_INTERNAL_BIOC=1)`, add a
+   top-level `air_gapped: true` (or `bioc: {mode: internal}`) knob in
+   `config.yml`. Env var stays as an override. Feels more discoverable.
+
+10. **Config discovery cascade docs + tests.**
+    `config_path` was recently added — document the resolution order
+    (arg > `val.pipeline.config_path` option > env `VAL_PIPELINE_CONFIG`
+    > pkg default) in `?pull_config` and add a `test-pull_config.R`
+    case for each layer if it isn't already there.
+
+---
+
+## Lower-impact / hygiene
+
+11. **`val_prep` object should be self-contained.**
+    So `val_pipeline(prep = readRDS("prep.rds"))` works across sessions
+    and machines. Requires storing config, opt_repos, val_date, package
+    list; avoid function references or lazy env captures.
+
+12. **CLI wrapper.**
+    `Rscript -e 'val.pipeline::val_pipeline_cli(...)'` or an
+    `inst/scripts/val-pipeline` file that parses `--config`, `--out`,
+    `--resume`, `--workers`. Air-gapped ops teams tend to prefer CLI
+    over interactive R sessions.
+
+13. **`val_decision.R` (690 lines) refactor.**
+    Biggest single file. Split by concern (rule parsing / evaluation /
+    rendering) and unit-test each piece. Comparable for `utils.R`
+    (1942 lines) — split at least `utils-riskmetric.R`,
+    `utils-config.R`, `utils-format.R`.
+
+14. **Snapshot tests for report rendering.**
+    Small fixture package + expected report — currently a lot of manual
+    round-trips. `_snaps/` already exists; add a quarto-render snap for
+    at least one pkg.
+
+15. **`NEWS.md` linkification.**
+    Autolink `#77`-style refs to GH PRs in `pkgdown` output.
+
+16. **Deprecation policy.**
+    `val.pipeline.config_path` option, `VAL_PIPELINE_INTERNAL_BIOC` env
+    — as knobs multiply, document lifecycle and use
+    `lifecycle::deprecate_*()` so users get warnings, not silent breaks.
+
+---
+
+## New capability ideas
+
+17. **`val_diff(prev_val_dir, this_val_dir)`.**
+    Rerun-friendly diff summary: added/removed packages, metric deltas,
+    score changes. Enormously valuable during quarterly re-validation
+    cycles.
+
+18. **Package allowlist / denylist.**
+    Config-level `deny: [pkg1, pkg2]` for orgs that must exclude
+    specific packages regardless of criteria.
+
+19. **`val_pipeline_report()` — an executive summary across all pkgs.**
+    You already have per-pkg reports; a single top-level PDF/HTML
+    aggregating pass/fail counts, top 10 risky packages, missing
+    metrics, run stats.
+
+---
+
+## Top-3 recommendation if picking a few
+
+- **#2 Fully resumable runs** — biggest quality-of-life win, especially
+  on the air-gapped server.
+- **#1 Config validation + versioning** — biggest robustness improvement.
+- **#4 Parallelism** — biggest wall-clock improvement.
+
+## Natural PR pairings
+
+- **#1 + #9** — config validation and the air-gapped opt-in are both
+  config-schema work.
+- **#2 + #8** — resume + dry_run touch the same entry-point plumbing.
+- **#3 + #5** — structured logging + manifest.json share a "write
+  metadata alongside the run" theme.
+- **#6 + #7** — retries + timeouts are both fault-tolerance around
+  external calls.

--- a/tests/testthat/test-configure-riskmetric-offline.R
+++ b/tests/testthat/test-configure-riskmetric-offline.R
@@ -127,3 +127,33 @@ test_that("configure_riskmetric_offline() also shims is_available_cran to prefer
                            function() fake_bioc, ns = "riskmetric")
   expect_false(patched("BiocGenerics", repos = character(), p = NULL))
 })
+
+
+test_that("configure_riskmetric_offline() also shims pkg_bioc to use the PPM URL", {
+  skip_if_not_installed("riskmetric")
+
+  orig_pkg_bioc <- getFromNamespace("pkg_bioc", ns = "riskmetric")
+  orig_bioc <- getFromNamespace("memoise_bioc_available", ns = "riskmetric")
+  on.exit({
+    utils::assignInNamespace("pkg_bioc", orig_pkg_bioc, ns = "riskmetric")
+    utils::assignInNamespace("memoise_bioc_available", orig_bioc,
+                             ns = "riskmetric")
+  }, add = TRUE)
+
+  expect_true(configure_riskmetric_offline(quiet = TRUE))
+
+  fake_bioc <- data.frame(
+    Package = "BiocGenerics", Version = "0.99.0",
+    Repository = "https://internal.example.com/bioc/src/contrib",
+    stringsAsFactors = FALSE
+  )
+  utils::assignInNamespace("memoise_bioc_available",
+                           function() fake_bioc, ns = "riskmetric")
+
+  patched <- getFromNamespace("pkg_bioc", ns = "riskmetric")
+  expect_false(identical(patched, orig_pkg_bioc))
+  p <- patched("BiocGenerics")
+  expect_s3_class(p, "pkg_bioc_remote")
+  expect_equal(p$repo, "https://internal.example.com/bioc")
+  expect_false(grepl("bioconductor.org", p$repo, fixed = TRUE))
+})

--- a/tests/testthat/test-configure-riskmetric-offline.R
+++ b/tests/testthat/test-configure-riskmetric-offline.R
@@ -52,3 +52,50 @@ test_that("configure_riskmetric_offline() installs an override on the assess met
     }
   )
 })
+
+
+test_that("configure_riskmetric_offline() also shims memoise_bioc_available", {
+  skip_if_not_installed("riskmetric")
+  skip_if_not_installed("memoise")
+
+  orig <- getFromNamespace("memoise_bioc_available", ns = "riskmetric")
+  on.exit(
+    utils::assignInNamespace("memoise_bioc_available", orig, ns = "riskmetric"),
+    add = TRUE
+  )
+
+  expect_true(configure_riskmetric_offline(quiet = TRUE))
+
+  patched <- getFromNamespace("memoise_bioc_available", ns = "riskmetric")
+  expect_false(identical(patched, orig))
+
+  # Under a stubbed available.packages() the shim must succeed rather than
+  # trying to reach bioconductor.org/packages/release/bioc/src/contrib/PACKAGES.
+  fake_ap <- matrix(
+    c("BiocGenerics", "0.99.0", "https://internal.example.com/bioc/src/contrib"),
+    nrow = 1, byrow = TRUE,
+    dimnames = list(NULL, c("Package", "Version", "Repository"))
+  )
+  fake_repos <- c(BioCsoft = "https://internal.example.com/bioc")
+
+  called <- 0L
+  with_mocked_bindings(
+    available.packages = function(repos = NULL, ...) {
+      called <<- called + 1L
+      fake_ap
+    },
+    .package = "utils",
+    {
+      with_mocked_bindings(
+        repositories = function(...) fake_repos,
+        .package = "BiocManager",
+        {
+          df <- patched()
+          expect_s3_class(df, "data.frame")
+          expect_true("BiocGenerics" %in% df[["Package"]])
+        }
+      )
+    }
+  )
+  expect_gt(called, 0L)
+})

--- a/tests/testthat/test-configure-riskmetric-offline.R
+++ b/tests/testthat/test-configure-riskmetric-offline.R
@@ -99,3 +99,31 @@ test_that("configure_riskmetric_offline() also shims memoise_bioc_available", {
   )
   expect_gt(called, 0L)
 })
+
+
+test_that("configure_riskmetric_offline() also shims is_available_cran to prefer BioC", {
+  skip_if_not_installed("riskmetric")
+
+  orig <- getFromNamespace("is_available_cran", ns = "riskmetric")
+  orig_bioc <- getFromNamespace("memoise_bioc_available", ns = "riskmetric")
+  on.exit({
+    utils::assignInNamespace("is_available_cran", orig, ns = "riskmetric")
+    utils::assignInNamespace("memoise_bioc_available", orig_bioc,
+                             ns = "riskmetric")
+  }, add = TRUE)
+
+  expect_true(configure_riskmetric_offline(quiet = TRUE))
+  patched <- getFromNamespace("is_available_cran", ns = "riskmetric")
+  expect_false(identical(patched, orig))
+
+  # Force memoise_bioc_available to report BiocGenerics as a BioC pkg,
+  # then verify the shim vetos the CRAN classification.
+  fake_bioc <- data.frame(
+    Package = "BiocGenerics", Version = "0.99.0",
+    Repository = "https://internal.example.com/bioc/src/contrib",
+    stringsAsFactors = FALSE
+  )
+  utils::assignInNamespace("memoise_bioc_available",
+                           function() fake_bioc, ns = "riskmetric")
+  expect_false(patched("BiocGenerics", repos = character(), p = NULL))
+})


### PR DESCRIPTION
Fixes an air-gapped failure surfaced by:

```r
Sys.setenv(R_BIOC_VERSION = "3.22")
options(BiocManager.check_repositories = FALSE)
configure_bioc_repositories_if_requested(quiet = TRUE)
configure_riskmetric_offline_if_requested(quiet = TRUE)
riskmetric::pkg_ref("BiocGenerics")

# Error in read.dcf(con) :
#   cannot open the connection to
#   'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'
```

...plus a cascade of follow-on failures caught during review (BioC packages misclassified as `pkg_cran_remote`, and a family of `pkg_assess()` metrics blowing up with `Failed to connect to bioconductor.org port 443: Connection refused`). Upstream fix proposed at [pharmaR/riskmetric#402](https://github.com/pharmaR/riskmetric/pull/402); until it lands val.pipeline patches the same functions in-session.

## Root cause

Four independent code paths in `riskmetric` reach the public `bioconductor.org` origin directly, bypassing `BiocManager::repositories()` — so the existing `configure_bioc_repositories()` shim can't rescue them:

1. `riskmetric:::assess_reverse_dependencies.default()` → `devtools::revdep(bioconductor = TRUE)` reads a `VIEWS` file the internal PPM does not serve.
2. `riskmetric:::memoise_bioc_available()` hard-codes `read.dcf(url("https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES"))`.
3. `riskmetric:::is_available_cran()` runs *before* `is_available_bioc()` inside `verify_pkg_source()`, so a package that appears in **both** the CRAN PPM and the BioC PPM (`BiocGenerics`, etc.) gets classified as `pkg_cran_remote`.
4. `riskmetric::pkg_bioc()` builds `x$repo` / `x$repo_base_url` from the hard-coded `https://bioconductor.org/packages/release/bioc` string instead of the `Repository` column returned by `memoise_bioc_available()`, so *every* downstream `pkg_assess()` metric that scrapes `x$web_html` (`has_news`, `remote_checks`, `news_current`, `has_vignettes`, `has_maintainer`, `bugs_status`, `has_source_control`, `has_bug_reports_url`, `license`, ...) hits the public origin.

## What changes

Extends `configure_riskmetric_offline()` (already shipping Shim 1 on `main` since 0.1.6) with **three additional** in-session `assignInNamespace()` shims, giving four total:

- **Shim 1 — `assess_reverse_dependencies.default`** (unchanged from 0.1.6): replaces the `devtools::revdep()` path with `utils::available.packages()` + `tools::dependsOnPkgs()`.
- **Shim 2 — `memoise_bioc_available`**: reads BioC repos from `options("repos")` (resolved via the priority chain below) and calls `utils::available.packages()`. Returns the same schema (`Package`, `Version`, `Repository`, ...) the original produced, wrapped in `memoise::memoise()` when available so repeated `pkg_ref()` calls stay cheap.
- **Shim 3 — `is_available_cran`**: wraps the original so a package that is *also* present in `memoise_bioc_available()` no longer wins the CRAN check. Restores `pkg_bioc_remote` classification when the internal PPM exposes both CRAN and BioC entries on `options("repos")`.
- **Shim 4 — `pkg_bioc`**: rewrites the constructor so `x$repo` / `x$repo_base_url` are pulled from the `Repository` column returned by `memoise_bioc_available()` (i.e. the internal PPM's BioC URL). Every `pkg_assess()` metric that consumes `x$web_html` now scrapes the internal mirror instead of `bioconductor.org`.

### BioC repo resolution

Shims 2 and 4 need to know *which* entries in `options("repos")` are BioC. The priority chain (highest wins) is:

1. `options("val.pipeline.bioc_repos")` — explicit character vector override for R session or `.Rprofile`.
2. `Sys.getenv("VAL_PIPELINE_BIOC_REPOS")` — comma-separated URLs; convenient for CI / container envs.
3. Entries in `options("repos")` whose *name* matches `^BioC` (the classic BioCManager layout: `BioCsoft`, `BioCann`, `BioCexp`, `BioCworkflows`, `BioCbooks`).
4. Entries in `options("repos")` whose *URL* contains `bioconductor` (catches consolidated single-repo PPM layouts, e.g. `options(repos = c(CRAN = "…/cran/…", BIOC = "…/bioconductor/…"))` or an unnamed BioC entry).

The last two catch the two most common PPM layouts we've seen in practice (per-repo alias vs. single consolidated repo). Callers on unusual layouts can override at (1) or (2) without touching config.

## Wiring

- **No new public API surface.** `configure_riskmetric_offline_if_requested()` (called by `val_pipeline()`, `val_prep_pipeline()`, and `val_build()`) is the entry point, and it stays gated on either:
  - `Sys.setenv(VAL_PIPELINE_INTERNAL_BIOC = 1)`, or
  - `default: air_gapped: true` in `inst/config.yml` (once #78 lands).
- Public-network users never opt in, so behaviour is unchanged for them.
- All four shims are installed atomically inside `configure_riskmetric_offline()`; each one is a no-op if the target symbol is missing (defensive `getFromNamespace()` + `tryCatch`).

## Compatibility

- No `DESCRIPTION` dep changes. `memoise` is already an indirect requirement via riskmetric; Shim 2 degrades gracefully to the un-memoised path when it isn't loadable.
- Signatures on all four functions are preserved. Data-frame shapes on the two returning functions (`memoise_bioc_available`, `pkg_bioc` metadata) match the released code.

## Tests

`tests/testthat/test-configure-riskmetric-offline.R` covers all four shims:

- Confirms each patched symbol is a different function object than the original.
- Uses `with_mocked_bindings()` to fake `BiocManager::repositories`, `utils::available.packages`, and the original `is_available_cran`/`pkg_bioc`, then exercises each shim and asserts it *never reaches `bioconductor.org`*.
- Round-trips a fake `BiocGenerics` entry through Shims 2 → 3 → 4 to prove classification lands on `pkg_bioc_remote` with `x$repo_base_url` pointing at the fake internal PPM URL, not `bioconductor.org`.

## Ordering / version

- Rebased on `main` (which now includes #82 at 0.1.7).
- Bumped to **`Version: 0.1.8`** — one patch above `main`.
- Diff is orthogonal to #78 / #79 / #80; happy to renumber if any of them land first.
