### PR TITLE
val_pkg(): prefer disk-only initial ref for BioC packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .Ruserdata
 .Renviron
 dev/riskassessments/*
+dev/riskmetric-bioc-available-shim.txt
+dev/air-gapped-bioc-mirror-config.txt
 
 # testthat scratch directories: some upstream packages' test suites
 # copy themselves into <pkg>-tests/ dirs at the repo root when they

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,27 @@
+# val.pipeline 0.1.7
+
+- `val_pkg()` now prefers a disk-only reference for the initial
+  assessment of Bioconductor packages instead of scraping
+  `bioconductor.org` via `pkg_bioc_remote`. On air-gapped Posit
+  Package Manager mirrors that broken scrape wiped out roughly half a
+  dozen primary metrics (`has_vignettes`, `has_news`, `license`,
+  `has_maintainer`, `has_bug_reports_url`, `has_source_control`) and
+  effectively forced `covr_coverage` to run on every BioC package,
+  defeating the point of the initial pass.
+  - The new fallback order for BioC packages is: `pkg_install` (when
+    the pkg is in `.libPaths()[1]`) -> `pkg_source` (when the tarball
+    has been untarred) -> skip.
+  - A new `default: bioc_initial_ref:` config knob controls the order,
+    with allowed values `install` (default), `source`, `remote`
+    (legacy scrape behaviour) and `skip` (no initial pass; final
+    `pkg_source` assessment always includes `covr_coverage`).
+  - `workable_assessments(source_ref = ...)` now records the actual
+    provenance of the initial pass (`install`, `source`, or `remote`)
+    rather than always claiming `"remote"`, so downstream reports no
+    longer misrepresent where BioC metrics came from.
+  - CRAN / GitHub packages are unaffected: the initial pass continues
+    to run as `pkg_cran_remote`. (#82)
+
 # val.pipeline 0.1.6
 
 - Add `configure_bioc_repositories()` and

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -183,113 +183,206 @@ val_pkg <- function(
     #
     ### Initial Assessment ###
     #
-    
-    # We will ALWAYS perform a "pkg_cran_remote" assessment first, because it is
-    # WAY faster (even faster than a "pkg_source" while excluding
-    # "covr_coverage") so that if any primary metrics have an auto_accept
-    # condition, we can then run again with a "pkg_source" ref while excluding
-    # "covr_coverage" for final output. However, 
-    init_pkg_ref <- riskmetric::pkg_ref(pkg, source = 
-        if(stringr::str_detect(tolower(repo_name), "bioc")) "pkg_bioc_remote" else "pkg_cran_remote")
-    val_msg("\n-->", pkg_v, "initial reference complete.\n",
-            min_level = "verbose")
-    
-    # Pull available {riskmetric} assessments
-    init_metrics <- riskmetric::all_assessments()
-    
-    # if it's a 'remote_only' pkg, and we only want to assess primary metrics,
-    # then we could do that here (below). For now, we'll leave it all since
-    # we'll want a report that is the most populated as possible
-    # remote_pkgs <- pull_config(val = "remote_only", rule_type = "default")
-    # if(pkg %in% remote_pkgs) {
-    #   # pull primary metrics only
-    #   prime_metrics <- build_decisions_df(rule_type = "decide") |>
-    #     dplyr::filter(tolower(metric_type) == "primary") |>
-    #     dplyr::pull(metric) |>
-    #     unique() %>%
-    #     paste("assess", ., sep = "_")
-    #   init_metrics <- init_metrics[names(init_metrics) %in% prime_metrics] 
-    # }
-    
-    # rm(pkg_assessment0)
-    init_pkg_assessment0 <-
-      init_pkg_ref |>
-      # dplyr::as_tibble() |> # no tibbles allowed for stip or riskreports
-      riskmetric::pkg_assess(assessments = init_metrics)
-    
-    # strip assessment of '.recording' attribute:
-    init_pkg_assessment <-
-      init_pkg_assessment0 |> 
-      strip_recording()
-    
-    init_pkg_scores <- riskmetric::pkg_score(init_pkg_assessment)
-    
-    init_assessed_end <- Sys.time()
-    init_ass_mins <- difftime(init_assessed_end, start, units = "mins")
-    init_ass_mins_txt <- utils::capture.output(init_assessed_end - start)
-    val_msg("\n-->", pkg_v, "initial assessment complete.\n",
-            min_level = "normal")
-    val_msg("----> (", init_ass_mins_txt, ")\n", min_level = "normal")
-    
-    
-    # Create workable DF of assessments
-    init_assessment_record <- workable_assessments(
-      pkg = pkg,
-      ver = ver,
-      val_date = val_date,
-      metric_pkg = metric_pkg,
-      source = list(assessment = init_pkg_assessment, scores = init_pkg_scores),
-      source_ref = "remote"
-    )
-    
-    # 
-    #### Initial Decision
-    #
-    init_viable_metrics <- init_pkg_scores |>
-      dplyr::as_tibble() |>
-      t() |>
-      as.data.frame() |>
-      dplyr::filter(!is.na(V1)) |>
-      # make rownames a column
-      tibble::rownames_to_column(var = "metric") |>
-      dplyr::pull(metric)
-    
-    if("r_cmd_check" %in% init_viable_metrics){
-      init_vm <- init_viable_metrics[which(init_viable_metrics != "r_cmd_check")]
-      init_viable_metrics <- c(init_vm, "r_cmd_check_warnings", "r_cmd_check_errors")
-    }
-    
-    init_decision <- 
-      val_decision( 
-        pkg = pkg,
-        source_df = init_assessment_record,
-        excl_metrics = NULL, # "covr_coverage", # Subset not really necessary
-        decisions = decisions,
-        else_cat = decisions[length(decisions)],
-        decisions_df = build_decisions_df(
-          rule_type = "decide",
-          # rule_type = "remote_reduce",  # Could use this one here.
-          viable_metrics = init_viable_metrics
-          )
-      )
-    
-    auto_accepted <-
-      init_decision |> 
-      # dplyr::select(package, final_risk, dplyr::ends_with("cataa"))
-      dplyr::select(dplyr::ends_with("cataa")) |>
-      as.vector() |> unlist() |> any()
 
-    # Should I also consider an auto_fail threshold?
+    # For BioC packages, an initial `pkg_bioc_remote` assessment scrapes
+    # the Bioconductor package HTML landing pages, NEWS pages and
+    # checkResults pages under bioconductor.org. Air-gapped PPM mirrors
+    # do not surface those paths (see dev/air-gapped-bioc-mirror-config.txt),
+    # so a family of primary metrics (`has_vignettes`, `has_news`,
+    # `license`, `has_maintainer`, `has_bug_reports_url`,
+    # `has_source_control`) collapse to NA and the resulting `auto_accepted`
+    # signal is almost always FALSE. That defeats the whole point of the
+    # initial pass (short-circuiting `covr_coverage` on genuinely low-risk
+    # packages) *and* misrepresents the package in a "remote" report.
+    #
+    # For BioC packages we therefore prefer a disk-only initial ref that
+    # riskmetric can service without any HTML scraping: `pkg_install` when
+    # the package is present in the pipeline's library (the common case:
+    # val_prep_pipeline() has already staged it into .libPaths()[1]),
+    # falling back to `pkg_source` when the tarball has been untarred but
+    # the package hasn't been installed yet. If neither is available the
+    # initial pass is skipped entirely; the final pkg_source assessment
+    # then always runs with `covr_coverage` included.
+    bioc_pkg <- isTRUE(stringr::str_detect(tolower(repo_name), "bioc"))
+    bioc_initial_ref <- if (bioc_pkg) {
+      knob <- tryCatch(
+        pull_config(val = "bioc_initial_ref", rule_type = "default"),
+        error = function(e) NULL
+      )
+      if (is.null(knob) || !nzchar(as.character(knob))) "install" else as.character(knob)
+    } else NA_character_
+
+    installed_here <- if (bioc_pkg) {
+      pkg %in% rownames(utils::installed.packages(lib.loc = .libPaths()[1]))
+    } else FALSE
+    source_here <- if (bioc_pkg && ref == "source") {
+      dir.exists(file.path(sourced, pkg))
+    } else FALSE
+
+    init_source <- if (!bioc_pkg) {
+      "pkg_cran_remote"
+    } else if (identical(bioc_initial_ref, "skip")) {
+      NA_character_
+    } else if (identical(bioc_initial_ref, "remote")) {
+      "pkg_bioc_remote"
+    } else if (identical(bioc_initial_ref, "source") && source_here) {
+      "pkg_source"
+    } else if (installed_here) {
+      "pkg_install"
+    } else if (source_here) {
+      "pkg_source"
+    } else {
+      NA_character_
+    }
+
+    do_init <- !is.na(init_source)
+
+    if (do_init) {
+      init_pkg_ref <- switch(
+        init_source,
+        pkg_install = riskmetric::pkg_ref(
+          pkg, source = "pkg_install", lib.loc = .libPaths()[1]
+        ),
+        pkg_source  = riskmetric::pkg_ref(
+          file.path(sourced, pkg), source = "pkg_source"
+        ),
+        riskmetric::pkg_ref(pkg, source = init_source)
+      )
+      val_msg("\n-->", pkg_v, "initial reference complete (",
+              init_source, ").\n",
+              min_level = "verbose")
+
+      # Pull available {riskmetric} assessments
+      init_metrics <- riskmetric::all_assessments()
+
+      # if it's a 'remote_only' pkg, and we only want to assess primary metrics,
+      # then we could do that here (below). For now, we'll leave it all since
+      # we'll want a report that is the most populated as possible
+      # remote_pkgs <- pull_config(val = "remote_only", rule_type = "default")
+      # if(pkg %in% remote_pkgs) {
+      #   # pull primary metrics only
+      #   prime_metrics <- build_decisions_df(rule_type = "decide") |>
+      #     dplyr::filter(tolower(metric_type) == "primary") |>
+      #     dplyr::pull(metric) |>
+      #     unique() %>%
+      #     paste("assess", ., sep = "_")
+      #   init_metrics <- init_metrics[names(init_metrics) %in% prime_metrics]
+      # }
+
+      # covr_coverage is expensive; keep it off the initial pass. It runs in
+      # the final pkg_source assessment when auto_accepted is FALSE.
+      init_metrics$assess_covr_coverage <- NULL
+
+      init_pkg_assessment0 <-
+        init_pkg_ref |>
+        # dplyr::as_tibble() |> # no tibbles allowed for stip or riskreports
+        riskmetric::pkg_assess(assessments = init_metrics)
+
+      # strip assessment of '.recording' attribute:
+      init_pkg_assessment <-
+        init_pkg_assessment0 |>
+        strip_recording()
+
+      init_pkg_scores <- riskmetric::pkg_score(init_pkg_assessment)
+
+      init_assessed_end <- Sys.time()
+      init_ass_mins <- difftime(init_assessed_end, start, units = "mins")
+      init_ass_mins_txt <- utils::capture.output(init_assessed_end - start)
+      val_msg("\n-->", pkg_v, "initial assessment complete.\n",
+              min_level = "normal")
+      val_msg("----> (", init_ass_mins_txt, ")\n", min_level = "normal")
+
+
+      # Create workable DF of assessments. `source_ref` records the
+      # provenance of the *initial* pass rather than always claiming
+      # "remote" -- BioC pkgs will read "install" or "source" now.
+      init_source_ref <- switch(init_source,
+        pkg_install = "install",
+        pkg_source  = "source",
+        "remote"
+      )
+      init_assessment_record <- workable_assessments(
+        pkg = pkg,
+        ver = ver,
+        val_date = val_date,
+        metric_pkg = metric_pkg,
+        source = list(assessment = init_pkg_assessment, scores = init_pkg_scores),
+        source_ref = init_source_ref
+      )
+
+      #
+      #### Initial Decision
+      #
+      init_viable_metrics <- init_pkg_scores |>
+        dplyr::as_tibble() |>
+        t() |>
+        as.data.frame() |>
+        dplyr::filter(!is.na(V1)) |>
+        # make rownames a column
+        tibble::rownames_to_column(var = "metric") |>
+        dplyr::pull(metric)
+
+      if("r_cmd_check" %in% init_viable_metrics){
+        init_vm <- init_viable_metrics[which(init_viable_metrics != "r_cmd_check")]
+        init_viable_metrics <- c(init_vm, "r_cmd_check_warnings", "r_cmd_check_errors")
+      }
+
+      init_decision <-
+        val_decision(
+          pkg = pkg,
+          source_df = init_assessment_record,
+          excl_metrics = NULL, # "covr_coverage", # Subset not really necessary
+          decisions = decisions,
+          else_cat = decisions[length(decisions)],
+          decisions_df = build_decisions_df(
+            rule_type = "decide",
+            # rule_type = "remote_reduce",  # Could use this one here.
+            viable_metrics = init_viable_metrics
+            )
+        )
+
+      auto_accepted <-
+        init_decision |>
+        # dplyr::select(package, final_risk, dplyr::ends_with("cataa"))
+        dplyr::select(dplyr::ends_with("cataa")) |>
+        as.vector() |> unlist() |> any()
+
+      # Should I also consider an auto_fail threshold?
+    } else {
+      # BioC pkg with no local install or source available (or user asked
+      # for "skip"). Skip the initial pass; the final pkg_source assessment
+      # below will always include covr_coverage.
+      val_msg("\n-->", pkg_v,
+              "skipped initial assessment (BioC pkg, no local install/source or bioc_initial_ref='skip').\n",
+              min_level = "normal")
+      init_pkg_ref        <- NULL
+      init_pkg_assessment <- NULL
+      init_pkg_scores     <- NULL
+      init_assessment_record <- NULL
+      init_decision       <- NULL
+      init_viable_metrics <- character(0)
+      auto_accepted       <- FALSE
+      init_ass_mins       <- as.difftime(0, units = "mins")
+    }
     
     
     #
     #### Final Assessment ###
     #
     src_ref <- if(ref == "source") 'pkg_source' else 'pkg_cran_remote'
-    if(src_ref == "pkg_cran_remote") {
+    # Reuse the initial assessment as the final one when the user asked
+    # for a remote-only run AND the initial pass actually happened AND
+    # it wasn't a stand-in for a source assessment (e.g. BioC + pkg_install
+    # or pkg_source used as the initial). Otherwise fall through to a
+    # full pkg_source pass.
+    reuse_init <- src_ref == "pkg_cran_remote" &&
+                  do_init &&
+                  !identical(init_source, "pkg_source")
+    if (reuse_init) {
       pkg_assessment <- init_pkg_assessment
       pkg_scores <- init_pkg_scores
-      val_msg("\n-->", pkg_v, "used initial 'pkg_cran_remote' assessment.\n",
+      val_msg("\n-->", pkg_v, "used initial '", init_source,
+              "' assessment as the final remote result.\n",
               min_level = "normal")
       exclude_met <- NULL
     } else {

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -250,7 +250,7 @@ val_pkg <- function(
       )
       val_msg("\n-->", pkg_v, "initial reference complete (",
               init_source, ").\n",
-              min_level = "verbose")
+              min_level = "normal")
 
       # Pull available {riskmetric} assessments
       init_metrics <- riskmetric::all_assessments()

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -49,7 +49,6 @@ default:
     
     gt
   ] 
-  decisions_lst: [Low, Medium, High]
   # Which riskmetric ref type to use for the *initial* assessment pass of
   # Bioconductor packages inside val_pkg(). Options:
   #   "install" — use pkg_ref(pkg, source = "pkg_install", lib.loc = .libPaths()[1]).
@@ -68,7 +67,14 @@ default:
   #     is not useful for your BioC subset and you're happy to pay the
   #     coverage cost on every BioC package.
   # CRAN / GitHub packages are unaffected by this knob.
+  #
+  # Positioned above `decisions_lst` deliberately: pull_config() treats
+  # every key that appears *after* `decisions_lst` as a rule entry, so
+  # placing scalar defaults below it would push them into `rule_lst` and
+  # blow up build_decisions_df() with `subscript out of bounds` when it
+  # tries to read a non-existent `cond` element off a bare string.
   bioc_initial_ref: install
+  decisions_lst: [Low, Medium, High]
   opt_repos: 
     CRAN: https://packagemanager.posit.co/cran/2026-06-21
     BioC: https://bioconductor.org/packages/3.22/bioc #https://packagemanager.posit.co/bioconductor/latest 

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -50,6 +50,25 @@ default:
     gt
   ] 
   decisions_lst: [Low, Medium, High]
+  # Which riskmetric ref type to use for the *initial* assessment pass of
+  # Bioconductor packages inside val_pkg(). Options:
+  #   "install" — use pkg_ref(pkg, source = "pkg_install", lib.loc = .libPaths()[1]).
+  #     Recommended default: reads DESCRIPTION/NEWS from the pipeline library
+  #     with no bioconductor.org scraping (works on air-gapped PPM hosts
+  #     where the /html/, /news/ and /checkResults/ trees are not mirrored).
+  #     Falls back to "source" when the package isn't installed yet, and to
+  #     "skip" when neither an install nor an untarred source is available.
+  #   "source"  — use pkg_ref(<sourced/pkg>, source = "pkg_source") when
+  #     ref = "source". Same offline behaviour, but slower than "install".
+  #   "remote"  — use pkg_ref(pkg, source = "pkg_bioc_remote"). Legacy
+  #     behaviour: scrapes bioconductor.org. Only useful on hosts with
+  #     outbound network access to bioconductor.org.
+  #   "skip"    — no initial pass; the final pkg_source assessment runs
+  #     with covr_coverage always included. Set this if the initial pass
+  #     is not useful for your BioC subset and you're happy to pay the
+  #     coverage cost on every BioC package.
+  # CRAN / GitHub packages are unaffected by this knob.
+  bioc_initial_ref: install
   opt_repos: 
     CRAN: https://packagemanager.posit.co/cran/2026-06-21
     BioC: https://bioconductor.org/packages/3.22/bioc #https://packagemanager.posit.co/bioconductor/latest 

--- a/tests/testthat/test-bioc-initial-ref-config.R
+++ b/tests/testthat/test-bioc-initial-ref-config.R
@@ -1,0 +1,26 @@
+test_that("default bioc_initial_ref config knob is 'install'", {
+  # pull_config() reads from the pre-packaged config.yml unless the user
+  # has set VAL_PIPELINE_CONFIG. The default shipped with the package
+  # should be "install" (disk-only, no bioconductor.org scraping).
+  withr::local_envvar(VAL_PIPELINE_CONFIG = "")
+  withr::local_options(val.pipeline.config = NULL)
+  expect_equal(pull_config(val = "bioc_initial_ref", rule_type = "default"),
+               "install")
+})
+
+test_that("bioc_initial_ref accepts the four documented values", {
+  cfg <- tempfile(fileext = ".yml")
+  on.exit(unlink(cfg), add = TRUE)
+  for (v in c("install", "source", "remote", "skip")) {
+    writeLines(c(
+      "default:",
+      "  decisions_lst: [Low, Medium, High]",
+      paste0("  bioc_initial_ref: ", v)
+    ), cfg)
+    withr::local_options(val.pipeline.config = cfg)
+    expect_equal(
+      pull_config(val = "bioc_initial_ref", rule_type = "default"),
+      v
+    )
+  }
+})


### PR DESCRIPTION
## Motivation

`val_pkg()` performs an initial `pkg_bioc_remote` assessment on Bioconductor packages before deciding whether the final `pkg_source` pass needs to include `covr_coverage`. On air-gapped Posit Package Manager (PPM) mirrors this initial pass is broken: PPM mirrors the Bioconductor package repo (`src/contrib/PACKAGES` + tarballs) but not the Bioconductor *website* paths that `riskmetric` scrapes for the primary metrics (see [dev/air-gapped-bioc-mirror-config.txt](../blob/riskmetric-bioc-available-shim/dev/air-gapped-bioc-mirror-config.txt) in the sibling shim PR for the enumeration). So half a dozen metrics collapse to NA:

| Metric | Source URL it can't reach |
|---|---|
| `has_vignettes`, `has_news`, `license`, `has_maintainer`, `has_bug_reports_url`, `has_source_control` | `bioconductor.org/packages/<ver>/bioc/html/<pkg>.html` |
| `news_current`, `news_urls` | `bioconductor.org/packages/<ver>/bioc/news/<pkg>/NEWS` |
| `remote_checks` | `bioconductor.org/checkResults/release/bioc-LATEST/<pkg>/` |

That in turn makes `auto_accepted` almost always FALSE for BioC packages, forcing every one of them through the expensive `covr_coverage` pass — the exact optimization the initial pass was designed to *avoid*.

## Change

For BioC packages, prefer a disk-only initial reference that `riskmetric` can service without any bioconductor.org calls:

1. **`pkg_install`** (default) — `riskmetric::pkg_ref(pkg, source = "pkg_install", lib.loc = .libPaths()[1])`. Reads `DESCRIPTION` / `NEWS` from the pipeline library. Works whenever `val_prep_pipeline()` has already staged the package into `.libPaths()[1]` (the common case).
2. **`pkg_source`** fallback — used when the package isn't installed yet but its tarball has been untarred into `sourced/<pkg>`.
3. **Skip** fallback — used when neither of the above is available. The final `pkg_source` assessment then runs with `covr_coverage` always included.

CRAN / GitHub packages are unchanged: the initial pass still runs as `pkg_cran_remote`.

## Config knob

New `default: bioc_initial_ref:` key in `inst/config.yml` with four documented values:

- `install` (default) — the fallback chain above.
- `source` — force `pkg_source` when available; otherwise the same chain.
- `remote` — legacy `pkg_bioc_remote` scraping behaviour (useful on hosts with outbound access to `bioconductor.org`).
- `skip` — no initial pass; final assessment always runs with `covr_coverage`.

## Provenance in reports

`workable_assessments(source_ref = ...)` now records the actual provenance of the initial pass (`install`, `source`, or `remote`) rather than always claiming `"remote"`. Downstream reports no longer misrepresent where BioC metrics came from.

## Compatibility

- No signature change on `val_pkg()` or any exported function.
- No new dependencies.
- The `ref = "remote"` short-circuit that reuses `init_pkg_assessment` as the final result is refined so it only fires when the initial pass was a genuine remote pass — not when it was a stand-in `pkg_install` / `pkg_source` assessment. This means a BioC pkg run with `ref = "remote"` may now do a second full `pkg_source` assessment. That's the safe behaviour but worth calling out; happy to add a distinct `ref = "remote"` short-circuit for BioC + `pkg_install` (would just reuse the install-based init) if you'd rather.
- `covr_coverage` is now explicitly stripped from the initial metrics set for all packages (previously only present-by-accident, no-op for remote refs). Explicit is safer once initial can be a `pkg_install` — which *does* run `covr` — and would otherwise pay the coverage cost twice.

## Tests

New `tests/testthat/test-bioc-initial-ref-config.R` covers:

1. Default `bioc_initial_ref` in the shipped `inst/config.yml` is `"install"`.
2. `pull_config()` correctly reads each of the four documented values (`install`, `source`, `remote`, `skip`) when set in a user config.

Integration coverage against `val_pkg()` itself is intentionally left out here — it requires a real installed BioC package + tarball fixture, which none of the existing tests have infrastructure for. Happy to add `skip_on_ci()`-guarded ones if you'd like.

## Versioning

Bumped to `0.1.7`. This currently collides with #79 / #81 which also bump to `0.1.7`; whichever merges first wins and the others rebase. Diff is orthogonal to all three.

## Related

- Depends conceptually on **#81** (the four riskmetric-namespace shims). This PR still helps even without #81 — `pkg_install` avoids the bad scrapes regardless — but the two together are the full air-gapped BioC story.
- Companion notes at `dev/air-gapped-bioc-mirror-config.txt` (on #81) enumerate the exact URL paths a static-mirror overlay would need to expose if you *want* the `remote` scrape to work on-network.

Opening as a **draft** for maintainer review — particularly around the `ref = "remote"` short-circuit question and the covr-strip semantics.