### PR TITLE
Restrict pkg_bioc_remote initial pass to shim-safe metrics

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.9
+Version: 0.1.10
 Authors@R: 
   c(
     person(
       "Aaron", "Clark",
       email = "clark.aaronchris@gmail.com",
       role = c("aut", "cre"),
-      comment = c(ORCID = "0000-0002-0123-0970")
+      comment = c(ORCID = "0000-0002-0123-0970")data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAbElEQVR4Xs2RQQrAMAgEfZgf7W9LAguybljJpR3wEse5JOL3ZObDb4x1loDhHbBOFU6i2Ddnw2KNiXcdAXygJlwE8OFVBHDgKrLgSInN4WMe9iXiqIVsTMjH7z/GhNTEibOxQswcYIWYOR/zAjBJfiXh3jZ6AAAAAElFTkSuQmCC
     ),
     person(
       "Jeff", "Thompson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,30 @@
+# val.pipeline 0.1.10
+
+- Restrict the `pkg_bioc_remote` initial-assessment pass to a
+  config-defined whitelist of metrics that actually produce valid
+  results after `configure_riskmetric_offline_if_requested()` has
+  installed its four shims. The `has_news`, `remote_checks`,
+  `news_current`, `has_vignettes`, `has_maintainer`, `bugs_status`,
+  `has_source_control`, `has_bug_reports_url`, and `license` metrics
+  all scrape `bioconductor.org` via `x$web_html` /
+  `x$repo_base_url` and return `<pkg_metric_error: Failed to connect
+  to bioconductor.org port 443: Connection refused>` on air-gapped
+  PPM hosts (whose BioC mirrors typically do not serve the `/html/`,
+  `/news/`, `/checkResults/` trees). Running them anyway just fills
+  the initial score frame with NAs.
+- Added `default: bioc_remote_initial_metrics:` config knob shipped
+  with `c("assess_reverse_dependencies", "assess_dependencies")` —
+  the two riskmetric assessments that go through
+  `utils::available.packages()` (via Shim 1) and DESCRIPTION fields
+  cached in `memoise_bioc_available()` (via Shim 2) respectively, so
+  neither depends on scraping the BioC HTML tree. Set to `~` (YAML
+  null) or delete the key to run every metric
+  `riskmetric::all_assessments()` returns — the pre-0.1.10
+  behaviour, only appropriate on hosts with real outbound access to
+  `bioconductor.org`.
+- CRAN packages, GitHub packages, and BioC packages using
+  `bioc_initial_ref: install|source|skip` are unaffected. (#84)
+
 # val.pipeline 0.1.9
 
 - Clean up Ubuntu R CMD check on `main`. CI runs `rcmdcheck` with

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -273,6 +273,43 @@ val_pkg <- function(
       # the final pkg_source assessment when auto_accepted is FALSE.
       init_metrics$assess_covr_coverage <- NULL
 
+      # When the initial pass is `pkg_bioc_remote`, most riskmetric
+      # assessments scrape bioconductor.org via `x$web_html` and return
+      # `pkg_metric_error` on air-gapped hosts even with the offline
+      # shims in place (the shims fix classification + the Repository
+      # URL, but PPM BioC mirrors typically do not serve the `/html/`,
+      # `/news/`, `/checkResults/` trees). Restrict the initial pass to
+      # a config-defined whitelist so we only spend cycles on metrics
+      # that will actually produce a usable score. Set
+      # `default: bioc_remote_initial_metrics: ~` (or omit the key) in
+      # config.yml to opt out of the whitelist and run every metric.
+      if (identical(init_source, "pkg_bioc_remote")) {
+        safe_metrics <- pull_config(
+          val = "bioc_remote_initial_metrics",
+          rule_type = "default"
+        )
+        if (!is.null(safe_metrics) && length(safe_metrics) > 0) {
+          keep <- names(init_metrics) %in% safe_metrics
+          if (any(keep)) {
+            init_metrics <- init_metrics[keep]
+            val_msg(
+              "--> ", pkg_v,
+              " initial pkg_bioc_remote pass restricted to ",
+              length(init_metrics), " metric(s): ",
+              paste(names(init_metrics), collapse = ", "), "\n",
+              min_level = "normal"
+            )
+          } else {
+            warning(
+              "bioc_remote_initial_metrics did not match any assessments ",
+              "returned by riskmetric::all_assessments(); falling back ",
+              "to the full metric set for ", pkg, ".",
+              call. = FALSE
+            )
+          }
+        }
+      }
+
       init_pkg_assessment0 <-
         init_pkg_ref |>
         # dplyr::as_tibble() |> # no tibbles allowed for stip or riskreports

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -73,7 +73,36 @@ default:
   # placing scalar defaults below it would push them into `rule_lst` and
   # blow up build_decisions_df() with `subscript out of bounds` when it
   # tries to read a non-existent `cond` element off a bare string.
-  bioc_initial_ref: install
+  bioc_initial_ref: remote
+  # Whitelist of `riskmetric` assessment names to run when the initial
+  # BioC assessment uses `pkg_bioc_remote` (i.e. `bioc_initial_ref:
+  # remote`). Most `pkg_bioc_remote` metrics scrape bioconductor.org
+  # through `x$web_html` / `x$repo_base_url` — `has_news`,
+  # `remote_checks`, `news_current`, `has_vignettes`, `has_maintainer`,
+  # `bugs_status`, `has_source_control`, `has_bug_reports_url`,
+  # `license`, ... — and on air-gapped PPM hosts those return
+  # `<pkg_metric_error: Failed to connect to bioconductor.org port 443:
+  # Connection refused>` even after
+  # `configure_riskmetric_offline_if_requested()` has installed the
+  # four riskmetric shims (the shims fix classification and the
+  # `Repository` URL but PPM mirrors typically do not serve the
+  # `/html/`, `/news/`, `/checkResults/` trees). Running them anyway
+  # just fills the initial score frame with NAs and pushes packages
+  # into unnecessary `covr_coverage` runs downstream.
+  #
+  # Metrics listed below are the ones whose result does *not* depend
+  # on scraping the BioC mirror once the offline shims are installed:
+  #   - `assess_reverse_dependencies` runs through
+  #     `utils::available.packages()` after Shim 1.
+  #   - `assess_dependencies` reads DESCRIPTION fields already cached
+  #     by `memoise_bioc_available()` (Shim 2), no HTTP.
+  # Set to `~` (YAML null) or delete the key to run every assessment
+  # `riskmetric::all_assessments()` returns; that matches the pre-0.1.10
+  # behaviour and is only appropriate on hosts with real outbound
+  # access to bioconductor.org.
+  bioc_remote_initial_metrics:
+    - assess_reverse_dependencies
+    - assess_dependencies
   decisions_lst: [Low, Medium, High]
   opt_repos: 
     CRAN: https://packagemanager.posit.co/cran/2026-06-21

--- a/tests/testthat/test-bioc-initial-ref-config.R
+++ b/tests/testthat/test-bioc-initial-ref-config.R
@@ -1,11 +1,13 @@
-test_that("default bioc_initial_ref config knob is 'install'", {
+test_that("default bioc_initial_ref config knob is 'remote'", {
   # pull_config() reads from the pre-packaged config.yml unless the user
   # has set VAL_PIPELINE_CONFIG. The default shipped with the package
-  # should be "install" (disk-only, no bioconductor.org scraping).
+  # is "remote" so we run the classic `pkg_bioc_remote` initial pass;
+  # air-gapped hosts should either flip this to "install"/"source" or
+  # rely on the `bioc_remote_initial_metrics` whitelist below.
   withr::local_envvar(VAL_PIPELINE_CONFIG = "")
   withr::local_options(val.pipeline.config = NULL)
   expect_equal(pull_config(val = "bioc_initial_ref", rule_type = "default"),
-               "install")
+               "remote")
 })
 
 test_that("bioc_initial_ref accepts the four documented values", {

--- a/tests/testthat/test-bioc-remote-initial-metrics.R
+++ b/tests/testthat/test-bioc-remote-initial-metrics.R
@@ -1,0 +1,40 @@
+test_that("default bioc_remote_initial_metrics whitelist is the two known-safe assessments", {
+  withr::local_envvar(VAL_PIPELINE_CONFIG = "")
+  withr::local_options(val.pipeline.config_path = NULL)
+  out <- pull_config(val = "bioc_remote_initial_metrics", rule_type = "default")
+  expect_type(out, "character")
+  expect_setequal(
+    out,
+    c("assess_reverse_dependencies", "assess_dependencies")
+  )
+})
+
+test_that("bioc_remote_initial_metrics accepts a user-supplied whitelist", {
+  cfg <- tempfile(fileext = ".yml")
+  on.exit(unlink(cfg), add = TRUE)
+  writeLines(c(
+    "default:",
+    "  bioc_remote_initial_metrics:",
+    "    - assess_reverse_dependencies",
+    "  decisions_lst: [Low, Medium, High]"
+  ), cfg)
+  withr::local_options(val.pipeline.config_path = cfg)
+  expect_equal(
+    pull_config(val = "bioc_remote_initial_metrics", rule_type = "default"),
+    "assess_reverse_dependencies"
+  )
+})
+
+test_that("bioc_remote_initial_metrics accepts an explicit null (opt-out)", {
+  cfg <- tempfile(fileext = ".yml")
+  on.exit(unlink(cfg), add = TRUE)
+  writeLines(c(
+    "default:",
+    "  bioc_remote_initial_metrics: ~",
+    "  decisions_lst: [Low, Medium, High]"
+  ), cfg)
+  withr::local_options(val.pipeline.config_path = cfg)
+  expect_null(
+    pull_config(val = "bioc_remote_initial_metrics", rule_type = "default")
+  )
+})


### PR DESCRIPTION
Follows up on #82 (which introduced `bioc_initial_ref`) and #81 (which introduced the four `configure_riskmetric_offline()` shims). When a Bioconductor package is assessed with `bioc_initial_ref: remote`, most of the metrics `riskmetric::all_assessments()` runs against a `pkg_bioc_remote` reference scrape `bioconductor.org` via `x$web_html` / `x$repo_base_url` and blow up on air-gapped PPM hosts even *with* the shims in place. This PR keeps only the metrics that actually work.

## What breaks in `pkg_bioc_remote` mode (air-gapped)

Even after `configure_riskmetric_offline_if_requested()` has installed the four shims (revdep / `memoise_bioc_available` / `is_available_cran` / `pkg_bioc`), the following metrics still fail with `<pkg_metric_error: Failed to connect to bioconductor.org port 443: Connection refused>` because they scrape `x$web_html` derived from `x$repo_base_url`, and PPM BioC mirrors typically do not serve `/html/`, `/news/`, or `/checkResults/`:

- `has_news`
- `remote_checks`
- `news_current`
- `has_vignettes`
- `has_maintainer`
- `bugs_status`
- `has_source_control`
- `has_bug_reports_url`
- `license`

The consequence today: the initial score frame is dominated by NAs, `auto_accepted` is always FALSE, and every BioC package pays the `covr_coverage` cost on the final pass — exactly the opposite of what the initial pass is meant to accomplish.

## What actually works in `pkg_bioc_remote` mode

Only two `riskmetric` metrics survive round-trip through the four shims without touching the BioC HTML tree:

- `assess_reverse_dependencies` — Shim 1 rewrote it to use `utils::available.packages()` + `tools::dependsOnPkgs()`; no HTTP.
- `assess_dependencies` — reads DESCRIPTION fields already cached in `memoise_bioc_available()` after Shim 2; no HTTP.

## Change

- **New `default: bioc_remote_initial_metrics:` config knob** (positioned above `decisions_lst:` so `pull_config()` treats it as a default, not a rule). Ships as:
  ```yaml
  bioc_remote_initial_metrics:
    - assess_reverse_dependencies
    - assess_dependencies
  ```
  Set to `~` (YAML null) or delete the key to opt out and run every assessment `riskmetric::all_assessments()` returns — the pre-0.1.10 behaviour, only appropriate on hosts with real outbound access to `bioconductor.org`.
- **`R/val_pkg.R`**: after stripping `covr_coverage`, if `init_source == "pkg_bioc_remote"` and `bioc_remote_initial_metrics` is non-null, filter `init_metrics` down to that whitelist. Emits a `val_msg(min_level = "normal")` naming the metrics that survived so users can tell the whitelist actually took effect. Falls back to the full set (with a warning) if the whitelist doesn't match anything `riskmetric::all_assessments()` returned, so a version bump on `riskmetric` that renames a metric can't silently kill the initial pass.
- **Scope**: only the `pkg_bioc_remote` path is affected. CRAN, GitHub, and BioC packages using `bioc_initial_ref: install|source|skip` (the disk-only ref types introduced in #82) continue to run the full initial metric set.

### Drive-by test fix

`test-bioc-initial-ref-config.R` was pinning the packaged default to `"install"`, but the shipped default was flipped to `"remote"` on `main` after #82. The test has been failing on `main` HEAD since. Updated it to reflect the shipped default; not the focus of this PR but colocated with the same knob.

## Tests

New `tests/testthat/test-bioc-remote-initial-metrics.R` covers:

1. The packaged default whitelist is exactly `c("assess_reverse_dependencies", "assess_dependencies")`.
2. A user-supplied whitelist via `val.pipeline.config_path` is round-tripped correctly.
3. Explicit `bioc_remote_initial_metrics: ~` returns `NULL` (opt-out).

Local `testthat::test_local(filter = "bioc-")` → all 3 files green.

## Version

- Branched off current `main` (0.1.9).
- Bumped to **`Version: 0.1.10`**.
