### PR TITLE
Hotfix: strip base64-image blob accidentally injected into Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,13 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
   c(
     person(
       "Aaron", "Clark",
       email = "clark.aaronchris@gmail.com",
       role = c("aut", "cre"),
-      comment = c(ORCID = "0000-0002-0123-0970")data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAbElEQVR4Xs2RQQrAMAgEfZgf7W9LAguybljJpR3wEse5JOL3ZObDb4x1loDhHbBOFU6i2Ddnw2KNiXcdAXygJlwE8OFVBHDgKrLgSInN4WMe9iXiqIVsTMjH7z/GhNTEibOxQswcYIWYOR/zAjBJfiXh3jZ6AAAAAElFTkSuQmCC
+      comment = c(ORCID = "0000-0002-0123-0970")
     ),
     person(
       "Jeff", "Thompson",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# val.pipeline 0.1.11
+
+- Hotfix: strip a stray `data:image/png;base64,...` blob that had been
+  accidentally glued onto the maintainer's `ORCID` field in
+  `Authors@R`. R CMD check on Ubuntu was failing every downstream PR
+  with `checking DESCRIPTION meta-information ... ERROR / Malformed
+  Authors@R field:`. The blob was introduced in `main` via #84 and had
+  begun propagating to every branch that merged main. No other
+  change. (#85)
+
 # val.pipeline 0.1.10
 
 - Restrict the `pkg_bioc_remote` initial-assessment pass to a


### PR DESCRIPTION
## The problem

R CMD check on Ubuntu is failing on every currently-open PR with:

```
* checking DESCRIPTION meta-information ... ERROR
Malformed Authors@R field:
Error in proc$get_built_file() : Build process failed
Execution halted
```

## Root cause

Commit `405214e` (merged as #84) accidentally glued a `data:image/png;base64,iVBORw0K...` blob onto the primary maintainer's `ORCID` field in `Authors@R`:

```r
comment = c(ORCID = "0000-0002-0123-0970")data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAbEl...
```

`git log -p -S "data:image/png;base64" -- DESCRIPTION` confirms `405214e` is the point of introduction — the blob was not present in `main` before that commit, and every commit since has carried it through.

Once #84 merged, the blob rode into `main` and started propagating to every branch that merges main (`parallel-val-build`, `riskmetric-bioc-available-shim`, `config-validation-and-air-gapped-knob`, `pkgdown-autolink-news`, ...). All of them now fail the exact same `Malformed Authors@R` check at the very first `* checking DESCRIPTION ...` step, well before any of their own changes get exercised.

## Fix

Delete the blob. That is the entire diff:

```
-      comment = c(ORCID = "0000-0002-0123-0970")data:image/png;base64,iVBORw0K…AElFTkSuQmCC
+      comment = c(ORCID = "0000-0002-0123-0970")
```

Verified locally with `tools:::.check_package_description("DESCRIPTION")` (silent = OK).

## Why a standalone hotfix

Fixing it at the source unblocks every open PR without them all needing to carry the same 1-line correction on their branch, and lets the two currently-red PRs (#80 already, #81 next merge from main) go green as soon as they rebase.

## Version

Bumped **0.1.10 → 0.1.11**. No functional change. `#84`'s NEWS entry stays untouched.
