### PR TITLE
val_build parallel-run followups: quarto race, verbose/config propagation, config + renv drift

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.11
+Version: 0.1.12
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.12
+Version: 0.1.13
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,28 @@
+# val.pipeline 0.1.12
+
+- Fix two `val_build(workers > 1)` bugs surfaced by a real 8-worker run:
+  - `quarto::quarto_render()` was blowing up with
+    `Error running quarto CLI from R` in every worker but one.
+    `riskreports::package_report()` copies its template files into
+    `options("riskreports_output_dir")`, renames one file to a
+    pkg-specific `prefix_output`, and then removes the leftovers.
+    `val_pkg()` pointed that option at a single shared `reports/`
+    directory, so 8 concurrent workers raced on the mid-flight
+    copy/rename/remove sequence and one worker's `quarto_render()`
+    tripped over another's cleanup. `val_pkg()` now renders into a
+    per-package scratch dir (`reports/.render_<pkg>_v<ver>/`), then
+    copies the produced output(s) up into `reports/` and cleans the
+    scratch dir on exit. Final layout is unchanged.
+  - `verbose = "minimal"` was silently reverting to `"normal"` inside
+    workers. `future::multisession` boots each worker in a fresh R
+    session that does *not* inherit the parent's `options()`, so the
+    `val.pipeline.verbose` option `apply_verbose()` set in the parent
+    never reached `val_msg()` inside the worker. The parallel branch
+    of `val_build()` now captures the resolved tier
+    (`getOption("val.pipeline.verbose")`) plus the user-supplied
+    `val.pipeline.config_path` and re-applies both at the top of every
+    `future_mapply()` task. (#80)
+
 # val.pipeline 0.1.11
 
 - Hotfix: strip a stray `data:image/png;base64,...` blob that had been

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# val.pipeline 0.1.12
+# val.pipeline 0.1.13
 
 - Fix two `val_build(workers > 1)` bugs surfaced by a real 8-worker run:
   - `quarto::quarto_render()` was blowing up with

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,21 @@
     (`getOption("val.pipeline.verbose")`) plus the user-supplied
     `val.pipeline.config_path` and re-applies both at the top of every
     `future_mapply()` task. (#80)
+- Config + lockfile drift picked up while shaking down the parallel
+  build: bump the pinned CRAN snapshot from `2026-06-21` to
+  `2026-07-21`, tighten the `downloads_1yr` Medium/Low cutoff from
+  240k to 200k, and comment out the `bioc_remote_initial_metrics`
+  block (the whitelist is currently blocking valid Bioc assessments
+  on hosts with outbound access; will revisit under a dedicated
+  issue). Adds `future`, `future.apply`, `globals`, `listenv`,
+  `parallelly`, and `codetools` to `renv.lock` so the parallel
+  branch of `val_build()` boots cleanly under `renv::restore()`.
+- `dev/dev_pipeline.R`: swap `devtools::load_all()` for
+  `devtools::install(quick = TRUE) + library(val.pipeline)` so
+  `workers > 1` doesn't hit `FutureLaunchError: there is no package
+  called 'val.pipeline'` — `future::multisession` workers boot with
+  the plain `.libPaths()` and can't see a `load_all()`-only shadow
+  namespace.
 
 # val.pipeline 0.1.11
 

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -377,8 +377,23 @@ val_build <- function(
     old_plan <- future::plan(future::multisession, workers = workers)
     on.exit(future::plan(old_plan), add = TRUE)
 
+    # `future::multisession` boots each worker in a fresh R session
+    # that does NOT inherit the parent's `options()`. Capture the
+    # verbose tier the parent resolved via apply_verbose() and re-apply
+    # it inside every worker task so val_msg()/val_pkg() honour the
+    # caller's `verbose = "minimal"` etc. instead of silently reverting
+    # to the "normal" default.
+    verbose_tier <- getOption("val.pipeline.verbose", "normal")
+    # Same story for the user-supplied config path -- resolve_config_path()
+    # inside the worker will otherwise fall back to the packaged config.
+    config_path_tier <- getOption("val.pipeline.config_path", NULL)
+
     pkg_bundles <- future.apply::future_mapply(
       FUN = function(pkg, ver, pkg_cnt) {
+        options(val.pipeline.verbose = verbose_tier)
+        if (!is.null(config_path_tier)) {
+          options(val.pipeline.config_path = config_path_tier)
+        }
         assess_one(pkg, ver, pkg_cnt,
                    is_dep_skip = FALSE,
                    failed_snapshot = character(0))

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -640,9 +640,25 @@ val_pkg <- function(
   #
   # ---- Build Report ----
   #
-  
+
   # file.edit(system.file("report/package/pkg_template.qmd", package = "riskreports"))
-  options(riskreports_output_dir = reports)
+  # `riskreports::package_report()` copies its template files into
+  # `options("riskreports_output_dir")`, `file.rename()`s one file to a
+  # pkg-specific `prefix_output`, then `file.remove()`s the leftovers.
+  # When multiple `val_pkg()` calls run in parallel (workers > 1 in
+  # val_build()) they all reach for the same shared `reports/`
+  # directory and race on the mid-flight copy/rename/remove sequence,
+  # so a sibling worker's `quarto::quarto_render()` blows up mid-flight
+  # with 'Error running quarto CLI from R'. Give each package its own
+  # scratch render directory so template files don't collide, then
+  # copy the produced output(s) back into the shared `reports/`
+  # afterwards. The parent workflow already indexes reports by their
+  # pkg/version filename, so the final layout is unchanged.
+  pkg_render_dir <- file.path(reports, paste0(".render_", pkg_v))
+  dir.create(pkg_render_dir, showWarnings = FALSE, recursive = TRUE)
+  on.exit(unlink(pkg_render_dir, recursive = TRUE, force = TRUE),
+          add = TRUE)
+  options(riskreports_output_dir = pkg_render_dir)
   pr <- riskreports::package_report(
     package_name = pkg,
     package_version = ver,
@@ -658,6 +674,16 @@ val_pkg <- function(
     ),
     quiet = TRUE, # To silence quarto output for readability
   )
+  # Move the produced output file(s) up into the shared reports dir so
+  # downstream lookups (which key off `reports/`) keep working. `pr` is
+  # the character vector of paths riskreports produced; anything else in
+  # the scratch dir is a template artifact and gets cleaned up by the
+  # on.exit() above.
+  if (length(pr) > 0L) {
+    dest_files <- file.path(reports, basename(pr))
+    file.copy(pr, dest_files, overwrite = TRUE, copy.date = TRUE)
+    pr <- dest_files
+  }
   # pr
   
   val_msg("\n-->", pkg_v,"Report built.\n", min_level = "normal")

--- a/dev/dev_pipeline.R
+++ b/dev/dev_pipeline.R
@@ -1,24 +1,26 @@
 
 # update pertinent pkgs as needed
-# remotes::install_github("pharmar/riskscore", force = TRUE, ref = "latest") # v0.1.1
+# remotes::install_github("pharmar/riskscore", force = TRUE, ref = "latest") # v0.1.2
 # utils::install.packages("riskmetric") # v0.2.5
+# packageVersion("riskscore")
+# packageVersion("riskmetric")
 # renv::snapshot()
 # restart R
 
 # Load package
 devtools::load_all()
 
-
+workers = 6
 ref = "source"
 metric_pkg = "riskmetric"
 deps = c("depends") #,"suggests") # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
 deps_recursive = TRUE
 # val_date = Sys.Date()
-val_date = as.Date("2026-07-20")
+val_date = as.Date("2026-07-30")
 replace = FALSE
 out = Sys.getenv("RISK_OUTPATH", unset = getwd())
 opt_repos =
-  c(CRAN = "https://packagemanager.posit.co/cran/2026-06-21",
+  c(CRAN = "https://packagemanager.posit.co/cran/2026-07-21",
     BioC = 'https://bioconductor.org/packages/3.22/bioc')
 verbose = 'normal'
 # config_path = NULL
@@ -41,14 +43,14 @@ prep <- val_prep_pipeline(
 
 # Create qualified pkg data.frame
 qual <- val_pipeline(
-  ref = "source",
-  metric_pkg = "riskmetric", 
-  deps = c("depends"), #, "suggests"), # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
-  deps_recursive = TRUE,
-  val_date = as.Date("2026-07-20"), #Sys.Date(),
-  # val_date = as.Date("2025-10-07"),
-  replace = FALSE, 
-  out = Sys.getenv("RISK_OUTPATH", unset = getwd()),
+  workers         = workers,
+  ref             = ref,
+  metric_pkg      = metric_pkg,
+  deps            = deps,
+  deps_recursive  = deps_recursive,
+  val_date        = val_date,
+  out             = out,
+  opt_repos       = opt_repos,
   verbose = 'minimal'
 )
 
@@ -58,160 +60,160 @@ qual <- val_pipeline(
 # 
 
 
-#
-# Inspect the assessment dir
-#
-# 
-val_date = as.Date("2026-07-20")
-val_date_txt <- gsub("-", "", val_date)
-val_dir <- file.path(
-  Sys.getenv("RISK_OUTPATH", unset = getwd()),
-  glue::glue('R_{getRversion()}'),
-  val_date_txt
-  )
-
-
-
-# # # Inspect files / pkgs assessed vs reports
-# assessed <- file.path(val_dir, "assessed")
-# meta_files <- list.files(assessed, pattern = "_meta.rds$")
-# ass_files <- list.files(assessed, pattern = "_assess_record.rds$")
-# ass_files |> length()
-# pkgs <- stringr::word(meta_files, sep = "_", start = 1)
-# pkgs |> length()
-# 
-# reports <- file.path(val_dir, "reports")
-# report_files <- list.files(reports) #, pattern = "_meta.rds$")
-# report_pkgs <- stringr::word(report_files, sep = "_", start = 3)
-# report_pkgs |> length()
-# 
-# pkgs[!pkgs %in% report_pkgs]
-
-
-
-# Review assessment df (below)
-
-
-# Review qual df
-decisions <- pull_config(val = "decisions_lst", rule_type = "default")
-qual_metadata <- readRDS(file.path(val_dir, "qual_metadata.rds"))
-qual <- qual_metadata #|>
-  # dplyr::mutate(decision = factor(decision, levels = decisions),
-  #               final_decision = factor(final_decision, levels = decisions)
-  #               )
-
-  
-
-
-  
-# Summarize Decisions & final decisions into table
-dec <- table(qual$decision_reason, qual$decision)
-dec
-findec <- table(qual$final_decision_reason, qual$final_decision)
-findec
-diff <- findec - dec
-diff
-
-
-
-# Were final decisions rendered in qual_metadata? If not, run this:
-
-
-slow <- qual |>
-  dplyr::filter(assessment_runtime_mins > 45)
-slow |> dplyr::select(pkg, assessment_runtime_txt)
-
-# Search for any 'unknown' repos
-unknown_repos <- qual |>
-  dplyr::filter(repos == "unknown")
-unknown_repos |> dplyr::select(pkg, repos)
-unknown_repos |> pull(pkg) |> length()
-
-
-#
-# Assemble the assessment's data.frame
-#
-assessed <- file.path(val_dir, "assessed")
-ass_files <- list.files(assessed, pattern = "_assessments.rds$")
-ass_length <- ass_files |> length() # assessment file count
-# Calculate percent of pkgs that ran an assessment, out of total pkgs in qual_metadata
-round((ass_files |> length()) / nrow(qual) * 100, 2)
-  # 72.11 percent of total
-
-
-#
-# If needed, rebuild assessments data.frame (qual_assessments.rds)
-#
-
-#
-# Option 1:
-# Start bundling rds files from assessment lists (rds) & score lists (Rds), OR...
-#
-
-# rm(assessment_bundle)
-# assessment_bundle <- purrr::map(ass_files, function(file){
-#   ass_cnt <- which(ass_files == file)
-#   # file <- ass_files[2] # for debugging
-#   score_file <- gsub("_assessments.rds$", "_scores.rds", file)
-#   if(file.exists(file.path(assessed, file))) pkg_assessment <- readRDS(file.path(assessed, file))
-#   if(file.exists(file.path(assessed, file))) pkg_scores <- readRDS(file.path(assessed, score_file))
-#   pkg_v <- gsub("_assessments.rds$", "", file)
-#   pkg <- stringr::word(pkg_v, 1, sep = "_")
-#   ver <- stringr::word(pkg_v, 2, sep = "_")
-# 
-#   cat(paste0("\n\n#", ass_cnt, " of ", ass_length, ": ", pkg))
-#   # pkg_assessment$downloads_1yr |> as.numeric()
-#   work_df <- workable_assessments(
-#     pkg = pkg,
-#     ver = ver,
-#     val_date = val_date,
-#     metric_pkg = metric_pkg,
-#     source = list(assessment = pkg_assessment, scores = pkg_scores),
-#     source_ref = "source" # constant for this date
+# #
+# # Inspect the assessment dir
+# #
+# # 
+# val_date = as.Date("2026-07-20")
+# val_date_txt <- gsub("-", "", val_date)
+# val_dir <- file.path(
+#   Sys.getenv("RISK_OUTPATH", unset = getwd()),
+#   glue::glue('R_{getRversion()}'),
+#   val_date_txt
 #   )
-#   work_df
-# }) |>
-#   purrr::reduce(dplyr::bind_rows)
-
-
-
-#
-# Option 2:
-# Assemble the assessment's data.frame by binding aesses_record's
-#
-
-# assessed <- file.path(val_dir, "assessed")
-# ass_files <- list.files(assessed, pattern = "_assess_record.rds$")
-# ass_length <- ass_files |> length() # assessment file count
-# # round((ass_files |> length()) / nrow(qual) * 100, 2) # 74.77 percent of total
-
-# Start bundling rds files from assessment & score Rds, OR...
-# rm(assessment_bundle)
-# assessment_bundle <- purrr::map(ass_files[1:3], function(file){
-#   # file <- ass_files[1]
-#   ass_cnt <- which(ass_files == file)
-#   # file <- ass_files[2] # for debugging
-#   # score_file <- gsub("_assessments.rds$", "_scores.rds", file)
-#   if(file.exists(file.path(assessed, file))) pkg_assess_record <- readRDS(file.path(assessed, file))
-#   pkg_v <- gsub("_assess_record.rds", "", file)
-#   pkg <- stringr::word(pkg_v, 1, sep = "_")
-#   ver <- stringr::word(pkg_v, 2, sep = "_")
+# 
+# 
+# 
+# # # # Inspect files / pkgs assessed vs reports
+# # assessed <- file.path(val_dir, "assessed")
+# # meta_files <- list.files(assessed, pattern = "_meta.rds$")
+# # ass_files <- list.files(assessed, pattern = "_assess_record.rds$")
+# # ass_files |> length()
+# # pkgs <- stringr::word(meta_files, sep = "_", start = 1)
+# # pkgs |> length()
+# # 
+# # reports <- file.path(val_dir, "reports")
+# # report_files <- list.files(reports) #, pattern = "_meta.rds$")
+# # report_pkgs <- stringr::word(report_files, sep = "_", start = 3)
+# # report_pkgs |> length()
+# # 
+# # pkgs[!pkgs %in% report_pkgs]
+# 
+# 
+# 
+# # Review assessment df (below)
+# 
+# 
+# # Review qual df
+# decisions <- pull_config(val = "decisions_lst", rule_type = "default")
+# qual_metadata <- readRDS(file.path(val_dir, "qual_metadata.rds"))
+# qual <- qual_metadata #|>
+#   # dplyr::mutate(decision = factor(decision, levels = decisions),
+#   #               final_decision = factor(final_decision, levels = decisions)
+#   #               )
+# 
 #   
-#   cat(paste0("\n\n#", ass_cnt, " of ", ass_length, ": ", pkg))
-#   # pkg_assessment$downloads_1yr |> as.numeric()
-#   pkg_assess_record
-# }) |>
-#   purrr::list_rbind()
-#   # purrr::reduce(dplyr::bind_rows)
-
-
-#
-# Save & or load result
-#
-# saveRDS(assessment_bundle, file.path(val_dir, "qual_assessments.rds"))
-assessment_bundle <- readRDS(file.path(val_dir, "qual_assessments.rds"))
-# # saveRDS(assessment_bundle, file.path("dev", "qual_assessments_20251028.rds"))
-# # assessment_bundle <- readRDS(file.path("dev", "qual_assessments_20251023.rds"))
+# 
+# 
+#   
+# # Summarize Decisions & final decisions into table
+# dec <- table(qual$decision_reason, qual$decision)
+# dec
+# findec <- table(qual$final_decision_reason, qual$final_decision)
+# findec
+# diff <- findec - dec
+# diff
+# 
+# 
+# 
+# # Were final decisions rendered in qual_metadata? If not, run this:
+# 
+# 
+# slow <- qual |>
+#   dplyr::filter(assessment_runtime_mins > 45)
+# slow |> dplyr::select(pkg, assessment_runtime_txt)
+# 
+# # Search for any 'unknown' repos
+# unknown_repos <- qual |>
+#   dplyr::filter(repos == "unknown")
+# unknown_repos |> dplyr::select(pkg, repos)
+# unknown_repos |> pull(pkg) |> length()
+# 
+# 
+# #
+# # Assemble the assessment's data.frame
+# #
+# assessed <- file.path(val_dir, "assessed")
+# ass_files <- list.files(assessed, pattern = "_assessments.rds$")
+# ass_length <- ass_files |> length() # assessment file count
+# # Calculate percent of pkgs that ran an assessment, out of total pkgs in qual_metadata
+# round((ass_files |> length()) / nrow(qual) * 100, 2)
+#   # 72.11 percent of total
+# 
+# 
+# #
+# # If needed, rebuild assessments data.frame (qual_assessments.rds)
+# #
+# 
+# #
+# # Option 1:
+# # Start bundling rds files from assessment lists (rds) & score lists (Rds), OR...
+# #
+# 
+# # rm(assessment_bundle)
+# # assessment_bundle <- purrr::map(ass_files, function(file){
+# #   ass_cnt <- which(ass_files == file)
+# #   # file <- ass_files[2] # for debugging
+# #   score_file <- gsub("_assessments.rds$", "_scores.rds", file)
+# #   if(file.exists(file.path(assessed, file))) pkg_assessment <- readRDS(file.path(assessed, file))
+# #   if(file.exists(file.path(assessed, file))) pkg_scores <- readRDS(file.path(assessed, score_file))
+# #   pkg_v <- gsub("_assessments.rds$", "", file)
+# #   pkg <- stringr::word(pkg_v, 1, sep = "_")
+# #   ver <- stringr::word(pkg_v, 2, sep = "_")
+# # 
+# #   cat(paste0("\n\n#", ass_cnt, " of ", ass_length, ": ", pkg))
+# #   # pkg_assessment$downloads_1yr |> as.numeric()
+# #   work_df <- workable_assessments(
+# #     pkg = pkg,
+# #     ver = ver,
+# #     val_date = val_date,
+# #     metric_pkg = metric_pkg,
+# #     source = list(assessment = pkg_assessment, scores = pkg_scores),
+# #     source_ref = "source" # constant for this date
+# #   )
+# #   work_df
+# # }) |>
+# #   purrr::reduce(dplyr::bind_rows)
+# 
+# 
+# 
+# #
+# # Option 2:
+# # Assemble the assessment's data.frame by binding aesses_record's
+# #
+# 
+# # assessed <- file.path(val_dir, "assessed")
+# # ass_files <- list.files(assessed, pattern = "_assess_record.rds$")
+# # ass_length <- ass_files |> length() # assessment file count
+# # # round((ass_files |> length()) / nrow(qual) * 100, 2) # 74.77 percent of total
+# 
+# # Start bundling rds files from assessment & score Rds, OR...
+# # rm(assessment_bundle)
+# # assessment_bundle <- purrr::map(ass_files[1:3], function(file){
+# #   # file <- ass_files[1]
+# #   ass_cnt <- which(ass_files == file)
+# #   # file <- ass_files[2] # for debugging
+# #   # score_file <- gsub("_assessments.rds$", "_scores.rds", file)
+# #   if(file.exists(file.path(assessed, file))) pkg_assess_record <- readRDS(file.path(assessed, file))
+# #   pkg_v <- gsub("_assess_record.rds", "", file)
+# #   pkg <- stringr::word(pkg_v, 1, sep = "_")
+# #   ver <- stringr::word(pkg_v, 2, sep = "_")
+# #   
+# #   cat(paste0("\n\n#", ass_cnt, " of ", ass_length, ": ", pkg))
+# #   # pkg_assessment$downloads_1yr |> as.numeric()
+# #   pkg_assess_record
+# # }) |>
+# #   purrr::list_rbind()
+# #   # purrr::reduce(dplyr::bind_rows)
+# 
+# 
+# #
+# # Save & or load result
+# #
+# # saveRDS(assessment_bundle, file.path(val_dir, "qual_assessments.rds"))
+# assessment_bundle <- readRDS(file.path(val_dir, "qual_assessments.rds"))
+# # # saveRDS(assessment_bundle, file.path("dev", "qual_assessments_20251028.rds"))
+# # # assessment_bundle <- readRDS(file.path("dev", "qual_assessments_20251023.rds"))
 
 
 

--- a/dev/dev_pipeline.R
+++ b/dev/dev_pipeline.R
@@ -8,7 +8,9 @@
 # restart R
 
 # Load package
-devtools::load_all()
+# devtools::load_all()
+devtools::install(quick = TRUE, upgrade = "never", quiet = TRUE)
+library(val.pipeline)
 
 workers = 6
 ref = "source"

--- a/inst/config.yml
+++ b/inst/config.yml
@@ -10,6 +10,7 @@ default:
     logrx, admiral, sdtm.oak, cardinal, admiral.test, admiralonco, admiralvaccine, tidytlg,
     pharmaversesdtm, pharmaverseadam, rlistings, sdtmchecks, metatools, admiraldev, admiralophtha,
     datacutr, admiralci, envsetup, cards, cardx, mmrm,
+    
     addinexamples, apt, assertr, autoslider.core, base, bbr,
     bbr.bayes, bcrm, berryFunctions, BiocParallel, BiocVersion, blogdown, chevron, clinfun,
     compareDF, compiler, condSURV, constructive, covtracer, crmPack, CTP, daff, data.validator,
@@ -100,12 +101,12 @@ default:
   # `riskmetric::all_assessments()` returns; that matches the pre-0.1.10
   # behaviour and is only appropriate on hosts with real outbound
   # access to bioconductor.org.
-  bioc_remote_initial_metrics:
-    - assess_reverse_dependencies
-    - assess_dependencies
+  # bioc_remote_initial_metrics:
+  #   - assess_reverse_dependencies
+  #   - assess_dependencies
   decisions_lst: [Low, Medium, High]
   opt_repos: 
-    CRAN: https://packagemanager.posit.co/cran/2026-06-21
+    CRAN: https://packagemanager.posit.co/cran/2026-07-21
     BioC: https://bioconductor.org/packages/3.22/bioc #https://packagemanager.posit.co/bioconductor/latest 
     
 remote_reduce:
@@ -113,8 +114,8 @@ remote_reduce:
   downloads_1yr:
     cond:
       High: ~ is.na(.x) | .x < 80000
-      Medium: ~ dplyr::between(.x, 80000, 240000)
-      Low: ~ .x > 240000
+      Medium: ~ dplyr::between(.x, 80000, 200000)
+      Low: ~ .x > 200000
     type: primary
     accept_cats: Low
     promote_min: ~ .x > 60000 # bare minimum needed for promo

--- a/renv.lock
+++ b/renv.lock
@@ -437,6 +437,23 @@
       "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
       "Repository": "https://packagemanager.posit.co/cran/__linux__/rhel9/latest"
     },
+    "codetools": {
+      "Package": "codetools",
+      "Version": "0.2-20",
+      "Source": "Repository",
+      "Priority": "recommended",
+      "Author": "Luke Tierney <luke-tierney@uiowa.edu>",
+      "Description": "Code analysis tools for R.",
+      "Title": "Code Analysis Tools for R",
+      "Depends": [
+        "R (>= 2.1)"
+      ],
+      "Maintainer": "Luke Tierney <luke-tierney@uiowa.edu>",
+      "URL": "https://gitlab.com/luke-tierney/codetools",
+      "License": "GPL",
+      "NeedsCompilation": "no",
+      "Repository": "CRAN"
+    },
     "commonmark": {
       "Package": "commonmark",
       "Version": "2.0.0",
@@ -1176,6 +1193,83 @@
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
       "Repository": "https://packagemanager.posit.co/cran/__linux__/rhel9/latest"
     },
+    "future": {
+      "Package": "future",
+      "Version": "1.70.0",
+      "Source": "Repository",
+      "Title": "Unified Parallel and Distributed Processing in R for Everyone",
+      "Depends": [
+        "R (>= 3.2.0)"
+      ],
+      "Imports": [
+        "digest",
+        "globals (>= 0.18.0)",
+        "listenv (>= 0.8.0)",
+        "parallel",
+        "parallelly (>= 1.44.0)",
+        "tools",
+        "utils"
+      ],
+      "Suggests": [
+        "methods",
+        "RhpcBLASctl",
+        "R.rsp",
+        "markdown"
+      ],
+      "VignetteBuilder": "R.rsp",
+      "Authors@R": "c(person(\"Henrik\", \"Bengtsson\", role = c(\"aut\", \"cre\", \"cph\"), email = \"henrikb@braju.com\", comment = c(ORCID = \"0000-0002-7579-5165\")))",
+      "Description": "The purpose of this package is to provide a lightweight and unified Future API for sequential and parallel processing of R expression via futures.  The simplest way to evaluate an expression in parallel is to use `x %<-% { expression }` with `plan(multisession)`. This package implements sequential, multicore, multisession, and cluster futures.  With these, R expressions can be evaluated on the local machine, in parallel a set of local machines, or distributed on a mix of local and remote machines. Extensions to this package implement additional backends for processing futures via compute cluster schedulers, etc. Because of its unified API, there is no need to modify any code in order switch from sequential on the local machine to, say, distributed processing on a remote compute cluster. Another strength of this package is that global variables and functions are automatically identified and exported as needed, making it straightforward to tweak existing code to make use of futures.",
+      "License": "LGPL (>= 2.1)",
+      "LazyLoad": "TRUE",
+      "ByteCompile": "TRUE",
+      "URL": "https://future.futureverse.org, https://github.com/futureverse/future",
+      "BugReports": "https://github.com/futureverse/future/issues",
+      "Language": "en-US",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.3",
+      "Collate": "'000.bquote.R' '000.import.R' '000.re-exports.R' '009.deprecation.R' '010.tweakable.R' '010.utils-parallelly.R' 'backend_api-01-FutureBackend-class.R' 'backend_api-03.MultiprocessFutureBackend-class.R' 'backend_api-11.ClusterFutureBackend-class.R' 'backend_api-11.MulticoreFutureBackend-class.R' 'backend_api-11.SequentialFutureBackend-class.R' 'backend_api-13.MultisessionFutureBackend-class.R' 'backend_api-ConstantFuture-class.R' 'backend_api-Future-class.R' 'backend_api-FutureRegistry.R' 'backend_api-UniprocessFuture-class.R' 'backend_api-evalFuture.R' 'core_api-cancel.R' 'core_api-future.R' 'core_api-reset.R' 'core_api-resolved.R' 'core_api-value.R' 'delayed_api-futureAssign.R' 'delayed_api-futureOf.R' 'demo_api-mandelbrot.R' 'infix_api-01-futureAssign_OP.R' 'infix_api-02-globals_OP.R' 'infix_api-03-seed_OP.R' 'infix_api-04-stdout_OP.R' 'infix_api-05-conditions_OP.R' 'infix_api-06-lazy_OP.R' 'infix_api-07-label_OP.R' 'infix_api-08-plan_OP.R' 'infix_api-09-tweak_OP.R' 'protected_api-FutureCondition-class.R' 'protected_api-FutureGlobals-class.R' 'protected_api-FutureResult-class.R' 'protected_api-futures.R' 'protected_api-globals.R' 'protected_api-journal.R' 'protected_api-resolve.R' 'protected_api-result.R' 'protected_api-signalConditions.R' 'testme.R' 'utils-basic.R' 'utils-conditions.R' 'utils-connections.R' 'utils-debug.R' 'utils-immediateCondition.R' 'utils-marshalling.R' 'utils-objectSize.R' 'utils-options.R' 'utils-prune_pkg_code.R' 'utils-registerClusterTypes.R' 'utils-rng_utils.R' 'utils-signalEarly.R' 'utils-stealth_sample.R' 'utils-sticky_globals.R' 'utils-tweakExpression.R' 'utils-uuid.R' 'utils-whichIndex.R' 'utils_api-backtrace.R' 'utils_api-capture_journals.R' 'utils_api-futureCall.R' 'utils_api-futureSessionInfo.R' 'utils_api-makeClusterFuture.R' 'utils_api-minifuture.R' 'utils_api-nbrOfWorkers.R' 'utils_api-plan.R' 'utils_api-plan-with.R' 'utils_api-sessionDetails.R' 'utils_api-tweak.R' 'zzz.R'",
+      "NeedsCompilation": "no",
+      "Author": "Henrik Bengtsson [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-7579-5165>)",
+      "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
+      "Repository": "CRAN"
+    },
+    "future.apply": {
+      "Package": "future.apply",
+      "Version": "1.20.2",
+      "Source": "Repository",
+      "Title": "Apply Function to Elements in Parallel using Futures",
+      "Depends": [
+        "R (>= 3.2.0)",
+        "future (>= 1.49.0)"
+      ],
+      "Imports": [
+        "globals",
+        "parallel",
+        "utils"
+      ],
+      "Suggests": [
+        "datasets",
+        "stats",
+        "tools",
+        "listenv",
+        "R.rsp",
+        "markdown"
+      ],
+      "VignetteBuilder": "R.rsp",
+      "Authors@R": "c(person(\"Henrik\", \"Bengtsson\", role = c(\"aut\", \"cre\", \"cph\"), email = \"henrikb@braju.com\", comment = c(ORCID = \"0000-0002-7579-5165\")), person(\"R Core Team\", role = c(\"cph\", \"ctb\")))",
+      "Description": "Implementations of apply(), by(), eapply(), lapply(), Map(), .mapply(), mapply(), replicate(), sapply(), tapply(), and vapply() that can be resolved using any future-supported backend, e.g. parallel on the local machine or distributed on a compute cluster. These future_*apply() functions come with the same pros and cons as the corresponding base-R *apply() functions but with the additional feature of being able to be processed via the future framework <doi:10.32614/RJ-2021-048>.",
+      "License": "GPL (>= 2)",
+      "LazyLoad": "TRUE",
+      "URL": "https://future.apply.futureverse.org, https://github.com/futureverse/future.apply",
+      "BugReports": "https://github.com/futureverse/future.apply/issues",
+      "Language": "en-US",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.3",
+      "NeedsCompilation": "no",
+      "Author": "Henrik Bengtsson [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-7579-5165>), R Core Team [cph, ctb]",
+      "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
+      "Repository": "CRAN"
+    },
     "generics": {
       "Package": "generics",
       "Version": "0.1.4",
@@ -1321,6 +1415,32 @@
       "Author": "Gábor Csárdi [aut, cre], RStudio [cph, fnd]",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
       "Repository": "https://packagemanager.posit.co/cran/__linux__/rhel9/latest"
+    },
+    "globals": {
+      "Package": "globals",
+      "Version": "0.19.1",
+      "Source": "Repository",
+      "Depends": [
+        "R (>= 3.1.2)"
+      ],
+      "Imports": [
+        "codetools"
+      ],
+      "Title": "Identify Global Objects in R Expressions",
+      "Authors@R": "c( person(\"Henrik\", \"Bengtsson\", role=c(\"aut\", \"cre\", \"cph\"), email=\"henrikb@braju.com\"), person(\"Davis\",\"Vaughan\", role=\"ctb\", email=\"davis@posit.co\"))",
+      "Description": "Identifies global (\"unknown\" or \"free\") objects in R expressions by code inspection using various strategies (ordered, liberal, conservative, or deep-first search). The objective of this package is to make it as simple as possible to identify global objects for the purpose of exporting them in parallel, distributed compute environments.",
+      "License": "LGPL (>= 2.1)",
+      "LazyLoad": "TRUE",
+      "ByteCompile": "TRUE",
+      "Language": "en-US",
+      "Encoding": "UTF-8",
+      "URL": "https://globals.futureverse.org, https://github.com/futureverse/globals",
+      "BugReports": "https://github.com/futureverse/globals/issues",
+      "RoxygenNote": "7.3.3",
+      "NeedsCompilation": "no",
+      "Author": "Henrik Bengtsson [aut, cre, cph], Davis Vaughan [ctb]",
+      "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
+      "Repository": "CRAN"
     },
     "glue": {
       "Package": "glue",
@@ -1847,6 +1967,34 @@
       "Maintainer": "Lionel Henry <lionel@posit.co>",
       "Repository": "RSPM"
     },
+    "listenv": {
+      "Package": "listenv",
+      "Version": "0.10.1",
+      "Source": "Repository",
+      "Depends": [
+        "R (>= 3.1.2)"
+      ],
+      "Suggests": [
+        "R.utils",
+        "R.rsp",
+        "markdown"
+      ],
+      "VignetteBuilder": "R.rsp",
+      "Title": "Environments Behaving (Almost) as Lists",
+      "Authors@R": "c(person(\"Henrik\", \"Bengtsson\", role=c(\"aut\", \"cre\", \"cph\"), email = \"henrikb@braju.com\"))",
+      "Description": "List environments are environments that have list-like properties.  For instance, the elements of a list environment are ordered and can be accessed and iterated over using index subsetting, e.g. 'x <- listenv(a = 1, b = 2); for (i in seq_along(x)) x[[i]] <- x[[i]] ^ 2; y <- as.list(x)'.",
+      "License": "LGPL (>= 2.1)",
+      "LazyLoad": "TRUE",
+      "URL": "https://listenv.futureverse.org, https://github.com/futureverse/listenv",
+      "BugReports": "https://github.com/futureverse/listenv/issues",
+      "RoxygenNote": "7.3.3",
+      "Encoding": "UTF-8",
+      "Language": "en-US",
+      "NeedsCompilation": "no",
+      "Author": "Henrik Bengtsson [aut, cre, cph]",
+      "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
+      "Repository": "CRAN"
+    },
     "magrittr": {
       "Package": "magrittr",
       "Version": "2.0.4",
@@ -2040,6 +2188,36 @@
       "NeedsCompilation": "yes",
       "Author": "Gábor Csárdi [aut, cre], Jim Hester [aut], Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>), Winston Chang [ctb] (R6, callr, processx), Ascent Digital Services [cph, fnd] (callr, processx), Hadley Wickham [ctb, cph] (cli, curl, pkgbuild, yaml), Jeroen Ooms [ctb] (curl, jsonlite), Maëlle Salmon [ctb] (desc, pkgsearch), Duncan Temple Lang [ctb] (jsonlite), Lloyd Hilaiel [cph] (jsonlite), Alec Wong [ctb] (keyring), Michel Berkelaar and lpSolve authors [ctb] (lpSolve), R Consortium [fnd] (pkgsearch), Jay Loden [ctb] (ps), Dave Daeschler [ctb] (ps), Giampaolo Rodola [ctb] (ps), Shawn Garbett [ctb] (yaml), Jeremy Stephens [ctb] (yaml), Kirill Simonov [ctb] (yaml), Yihui Xie [ctb] (yaml), Zhuoer Dong [ctb] (yaml), Jeffrey Horner [ctb] (yaml), Will Beasley [ctb] (yaml), Brendan O'Connor [ctb] (yaml), Gregory Warnes [ctb] (yaml), Michael Quinn [ctb] (yaml), Zhian Kamvar [ctb] (yaml), Charlie Gao [ctb] (yaml), Kuba Podgórski [ctb] (zip), Rich Geldreich [ctb] (zip)",
       "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
+      "Repository": "CRAN"
+    },
+    "parallelly": {
+      "Package": "parallelly",
+      "Version": "1.47.0",
+      "Source": "Repository",
+      "Title": "Enhancing the 'parallel' Package",
+      "Imports": [
+        "parallel",
+        "tools",
+        "utils"
+      ],
+      "Suggests": [
+        "commonmark",
+        "base64enc"
+      ],
+      "VignetteBuilder": "parallelly",
+      "Authors@R": "c( person(\"Henrik\", \"Bengtsson\", role = c(\"aut\", \"cre\", \"cph\"), email = \"henrikb@braju.com\", comment = c(ORCID = \"0000-0002-7579-5165\")), person(\"Mike\", \"Cheng\", role = c(\"ctb\"), email = \"mikefc@coolbutuseless.com\") )",
+      "Description": "Utility functions that enhance the 'parallel' package and support the built-in parallel backends of the 'future' package.  For example, availableCores() gives the number of CPU cores available to your R process as given by the operating system, 'cgroups' and Linux containers, R options, and environment variables, including those set by job schedulers on high-performance compute clusters. If none is set, it will fall back to parallel::detectCores(). Another example is makeClusterPSOCK(), which is backward compatible with parallel::makePSOCKcluster() while doing a better job in setting up remote cluster workers without the need for configuring the firewall to do port-forwarding to your local computer.",
+      "License": "LGPL (>= 2.1)",
+      "LazyLoad": "TRUE",
+      "ByteCompile": "TRUE",
+      "URL": "https://parallelly.futureverse.org, https://github.com/futureverse/parallelly",
+      "BugReports": "https://github.com/futureverse/parallelly/issues",
+      "Language": "en-US",
+      "Encoding": "UTF-8",
+      "RoxygenNote": "7.3.3",
+      "NeedsCompilation": "yes",
+      "Author": "Henrik Bengtsson [aut, cre, cph] (ORCID: <https://orcid.org/0000-0002-7579-5165>), Mike Cheng [ctb]",
+      "Maintainer": "Henrik Bengtsson <henrikb@braju.com>",
       "Repository": "CRAN"
     },
     "pillar": {
@@ -3017,7 +3195,7 @@
     },
     "riskscore": {
       "Package": "riskscore",
-      "Version": "0.1.1",
+      "Version": "0.1.2",
       "Source": "GitHub",
       "Title": "A Catalog for `riskmetric` Results Across Public Repositories",
       "Authors@R": "c(  person(\"Aaron\", \"Clark\", , \"clark.aaronchris@gmail.com\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0002-0123-0970\")), person(family = \"R Validation Hub\", role = c(\"cph\", \"fnd\")) )",
@@ -3042,7 +3220,7 @@
       "RemoteRepo": "riskscore",
       "RemoteUsername": "pharmar",
       "RemoteRef": "latest",
-      "RemoteSha": "b00d91b8dd286f43dd07ed175fd36cdc69c82464",
+      "RemoteSha": "64b1335f1c277e42f4fec684dd3de2d011e54914",
       "NeedsCompilation": "no",
       "Author": "Aaron Clark [cre, aut] (ORCID: <https://orcid.org/0000-0002-0123-0970>), R Validation Hub [cph, fnd]",
       "Maintainer": "Aaron Clark <clark.aaronchris@gmail.com>"


### PR DESCRIPTION
Followup PR to #80 (merged at 7fce916). Bundles the fixes and small config/lockfile drift that fell out of an 8-worker `val_pipeline()` shakedown run against a real 1600-pkg cohort. Version bump 0.1.11 → 0.1.13.

## Diff since 7fce916

Four commits on this branch:

### 1. `9f04d1e` — Fix `quarto_render()` race + `verbose`/`config_path` drop in `val_build(workers > 1)`

Two real bugs surfaced by the shakedown run:

**a. `quarto_render()` race in `reports/`.** `riskreports::package_report()` copies its template files into `options("riskreports_output_dir")`, does `file.rename(template, prefix_output_<pkg>)`, then `file.remove()`s the leftovers. `val_pkg()` pointed that option at a single shared `<out_dir>/reports/` directory, so N workers raced on the mid-flight copy/rename/remove and one worker's `quarto_render()` tripped over another's cleanup — failing with 'Error running quarto CLI from R' in every worker but one.

Fix: render into a per-package scratch dir (`reports/.render_<pkg>_v<ver>/`), then copy the produced output(s) up into `reports/` and clean the scratch dir on exit. Final on-disk layout is unchanged. `R/val_pkg.R`.

**b. `verbose = 'minimal'` silently reverted to `'normal'` inside workers.** `future::multisession` boots each worker in a fresh R session that does *not* inherit the parent's `options()`, so the `val.pipeline.verbose` option `apply_verbose()` set in the parent never reached `val_msg()` inside the worker. Same story for any user setting `options(val.pipeline.config_path = ...)` for a custom config.

Fix: the parallel branch of `val_build()` now captures the resolved verbose tier (`getOption('val.pipeline.verbose')`) plus `val.pipeline.config_path` and re-applies both at the top of every `future_mapply()` task. `R/val_build.R`.

### 2. `a2f76d3` — Bump to 0.1.13

`main` shipped 0.1.12 while this branch was open, so bump to 0.1.13 to keep the counter ahead. `DESCRIPTION` + `NEWS.md`.

### 3. `2e3a427` — Default config + `renv.lock` refresh

- Bump pinned CRAN snapshot `2026-06-21` → `2026-07-21` in `inst/config.yml`.
- Tighten `downloads_1yr` Medium/Low cutoff from `240000` → `200000`.
- Comment out the `bioc_remote_initial_metrics` whitelist — it's currently blocking valid Bioc assessments on hosts with real outbound access. Will revisit under a dedicated issue (not this PR).
- Add `future`, `future.apply`, `globals`, `listenv`, `parallelly`, `codetools` to `renv.lock` so the parallel branch of `val_build()` boots cleanly under `renv::restore()`.
- Housekeeping edits to `dev/dev_pipeline.R` (comments, formatting) from the same iteration.

### 4. `b14d66d` — `dev_pipeline.R`: install instead of `load_all` for `workers > 1`

`future::multisession` workers boot with the plain `.libPaths()` and can't see a `pkgload::load_all()` shadow namespace, so any workbench-job run of `dev/dev_pipeline.R` with `workers > 1` was failing with `FutureLaunchError: there is no package called 'val.pipeline'`. Swap `load_all()` for `devtools::install(quick = TRUE, upgrade = 'never', quiet = TRUE) + library(val.pipeline)` at the top of the script. Also extends the 0.1.13 `NEWS.md` section to cover the config + renv drift so the release notes match what actually shipped in this PR.

## Verification

- 8-worker `val_pipeline()` run against a real cohort no longer emits `quarto_render()` errors on any worker.
- `verbose = 'minimal'` is now honoured inside workers (verified by absence of the standard `val_msg()` output at that tier).
- `dev/dev_pipeline.R` runs end-to-end as a workbench job with `workers = 6` without the `FutureLaunchError`.

## Deferred (own issues)

- Local scratch dir + rsync-to-CIFS pattern for the per-pkg meta RDS update walk (`purrr::pwalk` at end of `val_build()`). Discussed but out of scope here.
- Algorithmic `reject_iteration()` rework (delta-based re-check on rev-dep index) — same story.
- Re-enable the `bioc_remote_initial_metrics` whitelist under a proper config-toggle so it only kicks in offline.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>