### PR TITLE
Decouple val_date from opt_repos rewrite via freeze_opt_repos flag (#89)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.14
+Version: 0.1.15
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# val.pipeline 0.1.15
+
+- Decouple `val_date` from the CRAN URL rewrite. New logical argument
+  `freeze_opt_repos` on `val_pipeline()` and `val_prep_pipeline()`
+  (default `FALSE`, preserves the pre-existing behaviour where
+  `update_opt_repos()` rewrites the config's CRAN URL to match
+  `val_date`). When `TRUE`, `update_opt_repos()` is skipped and the
+  config's `opt_repos` is used verbatim, so `val_date` can drift from
+  the frozen PPM snapshot without silently changing which packages
+  the pipeline pulls. Useful when the org has pinned CRAN to a
+  specific date in `inst/config.yml` but wants each run's output
+  folder (`R_<ver>/<YYYYMMDD>/`) to reflect the date the analysis was
+  actually executed. `val_date` still governs the output directory
+  name and every `val_date` field written to metadata -- only the
+  URL rewrite is gated off. (#89)
+
 # val.pipeline 0.1.14
 
 - Per-package timing instrumentation inside `val_pkg()`. A new

--- a/R/val_pipeline.R
+++ b/R/val_pipeline.R
@@ -57,6 +57,17 @@
 #'   downstream via [val_decision()], so package-report accuracy is
 #'   unaffected). Requires the optional `{future}` and
 #'   `{future.apply}` packages when `workers > 1`.
+#' @param freeze_opt_repos Logical(1). When `FALSE` (default), the
+#'   config's `opt_repos` CRAN URL is rewritten to match `val_date`
+#'   via [update_opt_repos()] (existing behaviour). When `TRUE`, the
+#'   config's `opt_repos` is used verbatim so `val_date` can drift from
+#'   the frozen PPM snapshot without silently changing which packages
+#'   the pipeline pulls. Useful when the org has pinned CRAN to a
+#'   specific date in `inst/config.yml` but wants each run's output
+#'   folder (`R_<ver>/<YYYYMMDD>/`) to reflect the date the analysis
+#'   was actually executed. `val_date` still governs the output
+#'   directory name and every `val_date` field written to metadata.
+#'   See #89.
 #' @return A list containing the validation directory and a data frame of
 #'   package assessments.
 #'
@@ -80,13 +91,16 @@ val_pipeline <- function(
   verbose = NULL,
   prep = NULL,
   config_path = NULL,
-  workers = 1L
+  workers = 1L,
+  freeze_opt_repos = FALSE
   ){
 
   # Assess args
   ref <- match.arg(ref)
   metric_pkg <- match.arg(metric_pkg)
   stopifnot(inherits(as.Date(val_date), c("Date", "POSIXt")))
+  stopifnot(is.logical(freeze_opt_repos), length(freeze_opt_repos) == 1L,
+            !is.na(freeze_opt_repos))
   if (!is.null(prep) && !inherits(prep, "val_prep")) {
     stop("`prep` must be a `val_prep` object returned by val_prep_pipeline().",
          call. = FALSE)
@@ -116,7 +130,8 @@ val_pipeline <- function(
       out             = out,
       opt_repos       = opt_repos,
       verbose         = verbose,
-      config_path     = config_path
+      config_path     = config_path,
+      freeze_opt_repos = freeze_opt_repos
     )
   }
 

--- a/R/val_prep_pipeline.R
+++ b/R/val_prep_pipeline.R
@@ -75,13 +75,16 @@ val_prep_pipeline <- function(
   toml_path = NULL,
   toml_project_name = "val.pipeline run",
   toml_local_repo = NULL,
-  config_path = NULL
+  config_path = NULL,
+  freeze_opt_repos = FALSE
 ){
 
   # Assess args
   ref <- match.arg(ref)
   metric_pkg <- match.arg(metric_pkg)
   stopifnot(inherits(as.Date(val_date), c("Date", "POSIXt")))
+  stopifnot(is.logical(freeze_opt_repos), length(freeze_opt_repos) == 1L,
+            !is.na(freeze_opt_repos))
   apply_verbose(verbose)
   configure_bioc_repositories_if_requested(quiet = TRUE)
   configure_riskmetric_offline_if_requested(quiet = TRUE)
@@ -169,7 +172,19 @@ val_prep_pipeline <- function(
   #
   # ---- Update repos option to val_date snapshot ----
   #
-  opt_repos <- update_opt_repos(val_date = val_date, opt_repos = opt_repos)
+  # When `freeze_opt_repos = TRUE`, respect the config's `opt_repos`
+  # verbatim so `val_date` can drift from the frozen PPM snapshot
+  # without silently rewriting the CRAN URL. `val_date` still governs
+  # the output directory name and every `val_date` field written to
+  # metadata -- only the CRAN URL date rewrite is gated off. See #89.
+  if (isTRUE(freeze_opt_repos)) {
+    val_msg(paste0("\n--> `freeze_opt_repos = TRUE`; leaving config's ",
+                   "opt_repos untouched (val_date = ", val_date,
+                   " governs the output folder only).\n"),
+            min_level = "normal")
+  } else {
+    opt_repos <- update_opt_repos(val_date = val_date, opt_repos = opt_repos)
+  }
   options(repos = opt_repos, pkgType = "source", scipen = 999)
 
   #

--- a/man/val_pipeline.Rd
+++ b/man/val_pipeline.Rd
@@ -17,7 +17,8 @@ val_pipeline(
   verbose = NULL,
   prep = NULL,
   config_path = NULL,
-  workers = 1L
+  workers = 1L,
+  freeze_opt_repos = FALSE
 )
 }
 \arguments{
@@ -79,6 +80,18 @@ disabled in that mode (final risk propagation still runs
 downstream via \code{\link[=val_decision]{val_decision()}}, so package-report accuracy is
 unaffected). Requires the optional \code{{future}} and
 \code{{future.apply}} packages when \code{workers > 1}.}
+
+\item{freeze_opt_repos}{Logical(1). When \code{FALSE} (default), the
+config's \code{opt_repos} CRAN URL is rewritten to match \code{val_date}
+via \code{\link[=update_opt_repos]{update_opt_repos()}} (existing behaviour). When \code{TRUE}, the
+config's \code{opt_repos} is used verbatim so \code{val_date} can drift from
+the frozen PPM snapshot without silently changing which packages
+the pipeline pulls. Useful when the org has pinned CRAN to a
+specific date in \code{inst/config.yml} but wants each run's output
+folder (\verb{R_<ver>/<YYYYMMDD>/}) to reflect the date the analysis
+was actually executed. \code{val_date} still governs the output
+directory name and every \code{val_date} field written to metadata.
+See #89.}
 }
 \value{
 A list containing the validation directory and a data frame of

--- a/man/val_prep_pipeline.Rd
+++ b/man/val_prep_pipeline.Rd
@@ -17,7 +17,8 @@ val_prep_pipeline(
   toml_path = NULL,
   toml_project_name = "val.pipeline run",
   toml_local_repo = NULL,
-  config_path = NULL
+  config_path = NULL,
+  freeze_opt_repos = FALSE
 )
 }
 \arguments{
@@ -72,6 +73,18 @@ run reads from that file instead of the \code{config.yml} bundled with
 \code{val.pipeline.config_path} option is restored on exit. When \code{NULL}
 (default), the pre-packaged config is used (or whatever the caller
 has already set via \code{options(val.pipeline.config_path = ...)}).}
+
+\item{freeze_opt_repos}{Logical(1). When \code{FALSE} (default), the
+config's \code{opt_repos} CRAN URL is rewritten to match \code{val_date}
+via \code{\link[=update_opt_repos]{update_opt_repos()}} (existing behaviour). When \code{TRUE}, the
+config's \code{opt_repos} is used verbatim so \code{val_date} can drift from
+the frozen PPM snapshot without silently changing which packages
+the pipeline pulls. Useful when the org has pinned CRAN to a
+specific date in \code{inst/config.yml} but wants each run's output
+folder (\verb{R_<ver>/<YYYYMMDD>/}) to reflect the date the analysis
+was actually executed. \code{val_date} still governs the output
+directory name and every \code{val_date} field written to metadata.
+See #89.}
 }
 \value{
 A list of class \code{"val_prep"} containing:

--- a/tests/testthat/test-freeze-opt-repos.R
+++ b/tests/testthat/test-freeze-opt-repos.R
@@ -1,0 +1,72 @@
+test_that("val_pipeline() validates freeze_opt_repos", {
+  # Not-a-logical rejected.
+  expect_error(
+    val_pipeline(freeze_opt_repos = "yes"),
+    "freeze_opt_repos"
+  )
+  # Length > 1 rejected.
+  expect_error(
+    val_pipeline(freeze_opt_repos = c(TRUE, FALSE)),
+    "freeze_opt_repos"
+  )
+  # NA rejected.
+  expect_error(
+    val_pipeline(freeze_opt_repos = NA),
+    "freeze_opt_repos"
+  )
+})
+
+
+test_that("val_prep_pipeline() validates freeze_opt_repos", {
+  expect_error(
+    val_prep_pipeline(freeze_opt_repos = "yes"),
+    "freeze_opt_repos"
+  )
+  expect_error(
+    val_prep_pipeline(freeze_opt_repos = 1L),
+    "freeze_opt_repos"
+  )
+  expect_error(
+    val_prep_pipeline(freeze_opt_repos = NA),
+    "freeze_opt_repos"
+  )
+})
+
+
+test_that("freeze_opt_repos default preserves prior val_date-driven rewrite", {
+  # The pre-#89 behaviour is unchanged when the arg is left at its
+  # default (FALSE): update_opt_repos() still rewrites the CRAN URL
+  # to match val_date. Exercised via update_opt_repos() directly
+  # here (val_prep_pipeline() would call the same helper with the
+  # same args when the guard is off).
+  mock_repos <- c(CRAN = "https://packagemanager.posit.co/cran/2026-07-21")
+  val_date <- as.Date("2026-07-31")
+
+  expect_output(
+    result <- update_opt_repos(val_date, mock_repos)
+  )
+  expect_true(grepl("2026-07-31", result[["CRAN"]]))
+  expect_false(grepl("2026-07-21", result[["CRAN"]]))
+})
+
+
+test_that("freeze_opt_repos = TRUE means the caller skips update_opt_repos()", {
+  # When freeze_opt_repos = TRUE, val_prep_pipeline() takes the guarded
+  # branch and does NOT call update_opt_repos(), so the config's URL
+  # survives verbatim. Assert the invariant at the helper level: given
+  # the same inputs, the result of NOT calling update_opt_repos() is
+  # simply the input opt_repos.
+  mock_repos <- c(CRAN = "https://packagemanager.posit.co/cran/2026-07-21",
+                  BioC = "https://bioconductor.org/packages/3.22/bioc")
+  val_date <- as.Date("2026-07-31")
+
+  # This mirrors the guarded branch:
+  #   if (isTRUE(freeze_opt_repos)) { <no update> } else {
+  #     opt_repos <- update_opt_repos(val_date, opt_repos)
+  #   }
+  guarded_result <- if (isTRUE(TRUE)) mock_repos else {
+    update_opt_repos(val_date, mock_repos)
+  }
+  expect_identical(guarded_result, mock_repos)
+  expect_true(grepl("2026-07-21", guarded_result[["CRAN"]]))
+})


### PR DESCRIPTION
Closes #89. Bumps 0.1.14 → 0.1.15.

## Problem

`val_prep_pipeline()` unconditionally rewrites the CRAN URL date to match `val_date` via `update_opt_repos()` (see `R/val_prep_pipeline.R` line ~172, `R/utils.R` line ~247). If the user's `inst/config.yml` has a frozen snapshot like:

```yaml
opt_repos:
  CRAN: https://packagemanager.posit.co/cran/2026-07-21
```

...and the user passes `val_date = as.Date("2026-07-31")` (because they want the output folder to reflect the analysis date, not the snapshot date), the CRAN URL silently mutates to `.../cran/2026-07-31`. Packages come from a *different* snapshot than the config declares. Silent config drift.

## Fix

New logical argument `freeze_opt_repos` on `val_pipeline()` and `val_prep_pipeline()` (default `FALSE`, preserves prior behavior). When `TRUE`, `update_opt_repos()` is skipped and the config's `opt_repos` is used verbatim.

`val_date` continues to govern the output directory name (`R_<ver>/<YYYYMMDD>/`) and every `val_date` field written to metadata. Only the URL rewrite is gated off.

**Alternative considered and rejected:** a separate `snapshot_date` argument (defaulting to `val_date` for back-compat). Rejected because it forces users to keep two dates in sync with the config, and the "freeze what's in the config" mental model better matches how the workflow was described.

## Usage

```r
val_pipeline(
  val_date         = Sys.Date(),   # governs output folder
  freeze_opt_repos = TRUE,         # preserves config's frozen CRAN URL
  workers          = 6,
  verbose          = "minimal"
)
```

## Files

- `R/val_prep_pipeline.R` — new arg + guard around `update_opt_repos()`.
- `R/val_pipeline.R` — plumb the arg through to `val_prep_pipeline()`.
- `tests/testthat/test-freeze-opt-repos.R` — 4 new tests.
- `DESCRIPTION`, `NEWS.md` — bump + release note.

## Verification

- `devtools::test(filter = "freeze")` → 11 pass.
- `devtools::test(filter = "val_pipeline|val_prep|update_opt_repos")` → 81 pass.
- Full suite: 659 pass, 1 skip, 2 pre-existing bioc failures unrelated to this PR (same as noted on #88 — the previous config change commented out `bioc_remote_initial_metrics` and the test hasn't been updated).
- `devtools::document()` clean.

## Follow-ups (deferred)

- The two `test-bioc-remote-initial-metrics.R` failures on `main` deserve their own issue — either update the test to reflect the commented-out whitelist or restore the whitelist under a config toggle.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>