### PR TITLE
Stream _meta.rds collation from disk; drop in-memory pkg_bundles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.15
+Version: 0.1.16
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,28 @@
+# val.pipeline 0.1.16
+
+- Stop accumulating per-package `meta_list` bundles in memory during
+  `val_build()`. Prior behaviour built a named list `pkg_bundles` of
+  every assessed pkg's full meta (recursive `depends`/`suggests`, a
+  full `R.Version()` dump under `sys_info`, plus `rev_deps` and
+  `timings`), and in parallel mode also shipped each bundle back
+  through the `future` IPC channel -- easily 1-3 GB on full CRAN +
+  BioC cohorts (~6000 pkgs) and a primary driver of the OOM crashes
+  that forced users to restart 40-hour runs 2-3 times. `val_build()`
+  now discards worker returns (`val_pkg()` already writes
+  `_meta.rds` to disk) and streams collation from those files:
+  `qual_metadata0.rds` (`pkgs_df0`) and `timings.csv` are built in a
+  single one-bundle-at-a-time disk pass, cutting collation-phase
+  peak memory from O(all bundles) to O(one bundle + derived rows).
+  `assessment_bundle` is also `rm()`+`gc()`'d immediately after
+  `qual_assessments.rds` is saved so it no longer overlaps
+  `pkgs_df0` in memory. No public API change; downstream artifacts
+  (`qual_assessments.rds`, `qual_metadata0.rds`, `qual_metadata.rds`,
+  per-pkg `_meta.rds`, `timings.csv`) are byte-equivalent to before.
+  Mid-run crash recovery is unchanged and free: rerun `val_pipeline()`
+  with the same args and the cached branch of `assess_one()`
+  short-circuits every previously-assessed pkg via its `_meta.rds`
+  file. (#91)
+
 # val.pipeline 0.1.15
 
 - Decouple `val_date` from the CRAN URL rewrite. New logical argument

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,15 @@
   Mid-run crash recovery is unchanged and free: rerun `val_pipeline()`
   with the same args and the cached branch of `assess_one()`
   short-circuits every previously-assessed pkg via its `_meta.rds`
-  file. (#91)
+  file. When `workers > 1`, the parallel branch now *also*
+  pre-filters those already-assessed pkgs out of the dispatch list
+  entirely (was: dispatch every pkg and let each worker hit the
+  cached branch, paying a full future/IPC round-trip plus cached
+  val_msg lines for zero real work). Restarting a crashed 40-hr run
+  now only re-dispatches the pkgs that still need real work. Serial
+  mode (`workers = 1`) still walks cached pkgs so it can accumulate
+  `dont_run` / `failed_pkgs` state for its dep-skip short-circuit.
+  (#91)
 
 # val.pipeline 0.1.15
 

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -415,7 +415,15 @@ val_build <- function(
     log_file_tier    <- getOption("val.pipeline.log_file", NULL)
     log_level_tier   <- getOption("val.pipeline.log_level", "normal")
 
-    pkg_bundles <- future.apply::future_mapply(
+    # Workers discard the meta_list return: val_pkg() has already
+    # persisted every artifact we care about (`_meta.rds`,
+    # `_assess_record.rds`, `_assessments.rds`, `_scores.rds`) inside
+    # `assessed/`. Shipping the full `meta_list` back through the
+    # `future` IPC channel and accumulating it into a named list of
+    # ~6000 bundles was a multi-GB memory sink on full CRAN+BioC runs
+    # and was the primary driver of the OOM crashes users hit mid-run.
+    # Downstream collation now streams from disk instead. See #91.
+    future.apply::future_mapply(
       FUN = function(pkg, ver, pkg_cnt) {
         options(val.pipeline.verbose = verbose_tier)
         if (!is.null(config_path_tier)) {
@@ -428,6 +436,7 @@ val_build <- function(
         assess_one(pkg, ver, pkg_cnt,
                    is_dep_skip = FALSE,
                    failed_snapshot = character(0))
+        invisible(NULL)
       },
       pkg     = pkgs,
       ver     = vers,
@@ -436,12 +445,19 @@ val_build <- function(
       USE.NAMES = FALSE,
       future.seed = TRUE
     )
-    names(pkg_bundles) <- pkgs
   } else {
-    pkg_bundles <- purrr::map2(pkgs, vers, function(pkg, ver){
-      pkg_cnt <- which(pkgs == pkg)
+    # Serial mode: dep-skip short-circuit lives here. We only need
+    # `$decision` + `$rev_deps` from each pkg_meta to update the
+    # `dont_run` / `failed_pkgs` state; the full meta_list is discarded
+    # after each iteration (already saved to disk by `val_pkg()` /
+    # the dep-skip branch of `assess_one()`). A plain `for` loop makes
+    # the per-iter release explicit and avoids the ~1-3 GB `pkg_bundles`
+    # list that used to accumulate on full CRAN+BioC cohorts. See #91.
+    for (i in seq_along(pkgs)) {
+      pkg <- pkgs[[i]]
+      ver <- vers[[i]]
       is_dep_skip <- pkg %in% dont_run
-      pkg_meta <- assess_one(pkg, ver, pkg_cnt,
+      pkg_meta <- assess_one(pkg, ver, i,
                              is_dep_skip = is_dep_skip,
                              failed_snapshot = failed_pkgs)
       if (!is_dep_skip && pkg_meta$decision != decisions[1]) {
@@ -449,12 +465,11 @@ val_build <- function(
                        pkg_meta$decision,"' risk. All packages that depend on it will also be marked as '",
                        decisions[length(decisions)],"' risk.\n\n"),
                 min_level = "normal")
-        dont_run    <<- c(dont_run, pkg_meta$rev_deps) |> unique()
-        failed_pkgs <<- c(failed_pkgs, pkg) |> unique()
+        dont_run    <- c(dont_run, pkg_meta$rev_deps) |> unique()
+        failed_pkgs <- c(failed_pkgs, pkg) |> unique()
       }
-      pkg_meta
-    }) |>
-      purrr::set_names(nm = pkgs)
+      rm(pkg_meta)
+    }
   }
   
   # Message
@@ -495,44 +510,62 @@ val_build <- function(
   val_msg(paste0("\n--> Saved assessment records to ",
                  qual_assessments_file, "\n"),
           min_level = "minimal")
-  
-  
+  # Release the (multi-hundred-MB on large cohorts) assessment_bundle
+  # before we start reading _meta.rds files back into memory. Prior
+  # behaviour held this alongside pkg_bundles and pkgs_df0 for the
+  # remainder of val_build(), spiking peak RSS. See #91.
+  rm(assessment_bundle)
+  invisible(gc(verbose = FALSE))
+
+
   #
   # ---- Collate Pkg Meta into DF ----
   #
-    # For Debugging
-    # meta_files <- list.files(assessed, pattern = "_meta.rds$")
-    # meta_length <- meta_files |> length() # assessment file count
-    # pkg_bundles <- purrr::map(meta_files, function(file){
-    #   # file <- meta_files[1] # for debugging
-    #   meta_cnt <- which(meta_files == file)
-    #   pkg_v <- gsub("_meta.rds", "", file)
-    #   pkg <- stringr::word(pkg_v, 1, sep = "_")
-    #   ver <- stringr::word(pkg_v, 2, sep = "_")
-    #   cat(paste0("\n\n#", meta_cnt, " of ", meta_length, ": ", pkg))
-    #   readRDS(file.path(assessed, file))
-    # }) 
-  
-  
-  # Reduce package bundles down into a data.frame containing specific info
-  # names(pkg_bundles)
-  # NB: single `dplyr::bind_rows(list_of_tibbles)` call instead of
-  # `purrr::reduce(bind_rows)` — same O(n) vs O(n^2) reason as the assessment
-  # collation above (#69).
-  pkgs_df0 <- purrr::map( pkg_bundles, ~ {
-      # .x <- pkg_bundles$askpass
-      x <- purrr::list_flatten(.x)
-      # x$depends  <- if(all(is.na(x$depends)))  NA_character_ else paste(x$depends, collapse = ", ")
-      # x$suggests <- if(all(is.na(x$suggests))) NA_character_ else paste(x$suggests, collapse = ", ")
-      
-      x$depends <- list(x$depends)
-      x$suggests <- list(x$suggests)
-      x$rev_deps <- list(x$rev_deps)
-      x$sys_info <- list(x$sys_info)
-      # x$repos <- list(x$repos)
-      dplyr::as_tibble(x)
-    }) |> 
-    dplyr::bind_rows()
+  # Stream `_meta.rds` files one at a time and derive both the
+  # `pkgs_df0` tibble rows AND the per-phase `timings_df` rows in a
+  # single disk pass. Peak memory during collation is O(1 bundle +
+  # accumulated 1-row tibbles) instead of O(all bundles), which cuts
+  # ~1-3 GB off the RSS ceiling on full CRAN+BioC runs. See #91.
+  meta_files <- list.files(assessed, pattern = "_meta.rds$")
+  if (length(meta_files) == 0L) {
+    stop("No `_meta.rds` files found under ", assessed,
+         " to collate into `qual_metadata0.rds`.", call. = FALSE)
+  }
+
+  pkgs_df0_rows <- vector("list", length(meta_files))
+  timings_rows  <- vector("list", length(meta_files))
+  for (i in seq_along(meta_files)) {
+    bundle <- readRDS(file.path(assessed, meta_files[[i]]))
+    # Peel off timings before list_flatten so the phase names don't
+    # explode into per-column entries in the pkgs_df0 tibble.
+    tmap <- bundle[["timings"]]
+    bundle[["timings"]] <- NULL
+
+    x <- purrr::list_flatten(bundle)
+    x$depends  <- list(x$depends)
+    x$suggests <- list(x$suggests)
+    x$rev_deps <- list(x$rev_deps)
+    x$sys_info <- list(x$sys_info)
+    pkgs_df0_rows[[i]] <- dplyr::as_tibble(x)
+
+    if (!is.null(tmap) && length(tmap) > 0L) {
+      pkg_name <- bundle[["pkg"]]
+      ver_val  <- bundle[["ver"]]
+      if (is.null(ver_val)) ver_val <- NA_character_
+      timings_rows[[i]] <- purrr::imap(tmap, function(secs, phase) {
+        data.frame(
+          pkg     = pkg_name,
+          ver     = as.character(ver_val),
+          phase   = phase,
+          seconds = as.numeric(secs),
+          stringsAsFactors = FALSE
+        )
+      }) |> purrr::list_rbind()
+    }
+    rm(bundle)
+  }
+  pkgs_df0 <- dplyr::bind_rows(pkgs_df0_rows)
+  rm(pkgs_df0_rows)
   
   
   # Interim snapshot BEFORE dependency-based decision propagation runs.
@@ -630,27 +663,15 @@ val_build <- function(
   #
   # ---- Aggregate per-package timings ----
   #
-  # Every val_pkg() bundle carries a `$timings` list keyed by the
-  # val_time_block() labels (`download`, `untar`, `assess_initial`,
-  # `assess_final`, `decision`, `report`). Explode those into a long
-  # data.frame and write it as `timings.csv` under val_dir for
-  # later profiling analysis. Skipped pkgs (dep-skip pre-filter) have
-  # no timings; they contribute zero rows. See #87.
-  timings_df <- purrr::imap(pkg_bundles, function(bundle, pkg_name) {
-    tmap <- bundle[["timings"]]
-    if (is.null(tmap) || length(tmap) == 0L) return(NULL)
-    ver <- bundle[["ver"]]
-    if (is.null(ver)) ver <- NA_character_
-    purrr::imap(tmap, function(secs, phase) {
-      data.frame(
-        pkg     = pkg_name,
-        ver     = as.character(ver),
-        phase   = phase,
-        seconds = as.numeric(secs),
-        stringsAsFactors = FALSE
-      )
-    }) |> purrr::list_rbind()
-  }) |> purrr::list_rbind()
+  # Timings rows were built in the same disk-streaming pass that
+  # produced `pkgs_df0` (see the "Collate Pkg Meta into DF" block
+  # above). Here we simply flatten them into one long data.frame and
+  # write it as `timings.csv` under val_dir for later profiling
+  # analysis. Skipped pkgs (dep-skip pre-filter) contribute zero rows.
+  # See #87 for the timings feature and #91 for the disk-streaming
+  # collation that folded this into a single pass.
+  timings_df <- purrr::list_rbind(purrr::compact(timings_rows))
+  rm(timings_rows)
   
   if (nrow(timings_df) > 0L) {
     timings_file <- file.path(val_dir, "timings.csv")

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -415,6 +415,31 @@ val_build <- function(
     log_file_tier    <- getOption("val.pipeline.log_file", NULL)
     log_level_tier   <- getOption("val.pipeline.log_level", "normal")
 
+    # Pre-filter already-assessed pkgs before dispatch. In parallel
+    # mode there's no dep-skip state to update in-loop, so any pkg
+    # whose `_meta.rds` is already on disk (and `replace = FALSE`)
+    # would just hit the cached branch of `assess_one()` after paying
+    # a full future/IPC round-trip and a spam of val_msg lines. Filter
+    # those out up front. This turns a crashed 40-hr run's restart
+    # from "dispatch 6000 workers that each print a 'cached' line"
+    # into "dispatch only the N pkgs that still need real work". #91.
+    todo <- seq_along(pkgs)
+    if (!replace) {
+      pkg_v_all <- paste(pkgs, vers, sep = "_")
+      existing_meta <- file.path(assessed,
+                                 paste0(pkg_v_all, "_meta.rds"))
+      already_done <- file.exists(existing_meta)
+      n_skip <- sum(already_done)
+      if (n_skip > 0L) {
+        val_msg(paste0("\n--> Skipping ", n_skip, " of ", pkgs_length,
+                       " package(s) already assessed on disk ",
+                       "(`_meta.rds` present under `assessed/`). ",
+                       "Set `replace = TRUE` to re-run them.\n"),
+                min_level = "minimal")
+        todo <- which(!already_done)
+      }
+    }
+
     # Workers discard the meta_list return: val_pkg() has already
     # persisted every artifact we care about (`_meta.rds`,
     # `_assess_record.rds`, `_assessments.rds`, `_scores.rds`) inside
@@ -423,28 +448,36 @@ val_build <- function(
     # ~6000 bundles was a multi-GB memory sink on full CRAN+BioC runs
     # and was the primary driver of the OOM crashes users hit mid-run.
     # Downstream collation now streams from disk instead. See #91.
-    future.apply::future_mapply(
-      FUN = function(pkg, ver, pkg_cnt) {
-        options(val.pipeline.verbose = verbose_tier)
-        if (!is.null(config_path_tier)) {
-          options(val.pipeline.config_path = config_path_tier)
-        }
-        if (!is.null(log_file_tier) && nzchar(log_file_tier)) {
-          options(val.pipeline.log_file  = log_file_tier,
-                  val.pipeline.log_level = log_level_tier)
-        }
-        assess_one(pkg, ver, pkg_cnt,
-                   is_dep_skip = FALSE,
-                   failed_snapshot = character(0))
-        invisible(NULL)
-      },
-      pkg     = pkgs,
-      ver     = vers,
-      pkg_cnt = seq_along(pkgs),
-      SIMPLIFY  = FALSE,
-      USE.NAMES = FALSE,
-      future.seed = TRUE
-    )
+    if (length(todo) > 0L) {
+      future.apply::future_mapply(
+        FUN = function(pkg, ver, pkg_cnt) {
+          options(val.pipeline.verbose = verbose_tier)
+          if (!is.null(config_path_tier)) {
+            options(val.pipeline.config_path = config_path_tier)
+          }
+          if (!is.null(log_file_tier) && nzchar(log_file_tier)) {
+            options(val.pipeline.log_file  = log_file_tier,
+                    val.pipeline.log_level = log_level_tier)
+          }
+          assess_one(pkg, ver, pkg_cnt,
+                     is_dep_skip = FALSE,
+                     failed_snapshot = character(0))
+          invisible(NULL)
+        },
+        pkg     = pkgs[todo],
+        ver     = vers[todo],
+        pkg_cnt = todo,
+        SIMPLIFY  = FALSE,
+        USE.NAMES = FALSE,
+        future.seed = TRUE
+      )
+    } else {
+      val_msg(paste0("\n--> All ", pkgs_length,
+                     " package(s) already assessed on disk; ",
+                     "skipping the parallel assessment phase and ",
+                     "proceeding straight to collation.\n"),
+              min_level = "minimal")
+    }
   } else {
     # Serial mode: dep-skip short-circuit lives here. We only need
     # `$decision` + `$rev_deps` from each pkg_meta to update the


### PR DESCRIPTION
Closes #91.

## What

Refactor `val_build()` to stop accumulating per-package `meta_list` bundles in memory. Downstream artifacts (`qual_metadata0.rds`, `timings.csv`) are now rebuilt via a streaming disk pass over `assessed/*_meta.rds`.

## Why

Full CRAN + BioC runs (~6000 pkgs, ~40 hrs) OOM-crash the host mid-way, forcing users to restart the pipeline 2-3 times. Root cause was memory growth in `val_build()`:

- The per-pkg loop returned a full `meta_list` from every iteration and accumulated them into a named list `pkg_bundles`.
- Each bundle carries `sys_info` (full `R.Version()` dump), recursive `depends` / `suggests` / `rev_deps` vectors (thousands of entries for foundational pkgs), `repos`, plus `timings`.
- On 6000 pkgs `pkg_bundles` alone easily hit 1-3 GB.
- In parallel mode every worker also shipped its `meta_list` back through the `future` IPC channel.
- Later in `val_build()`, `assessment_bundle` (1-2 GB) was materialized in memory *simultaneously* with `pkg_bundles` and `pkgs_df0`. Peak ~3-6 GB retained.

## How

**`R/val_build.R`:**

1. **Parallel branch** — `future_mapply` FUN now calls `assess_one(...)` for its side effect (the on-disk `_meta.rds`) and returns `invisible(NULL)`. No bundle crosses the IPC boundary.
2. **Serial branch** — swapped `purrr::map2` for a plain `for` loop that reads only `pkg_meta$decision` + `pkg_meta$rev_deps` for the dep-skip short-circuit, then `rm(pkg_meta)` before the next iteration.
3. **`assessment_bundle` release** — after `saveRDS(assessment_bundle, qual_assessments_file)`, `rm(assessment_bundle); invisible(gc(verbose = FALSE))`. No longer overlaps with `pkgs_df0` in memory.
4. **Streaming meta collation** — replaced the `purrr::map(pkg_bundles, ~ list_flatten + as_tibble) |> bind_rows()` block with a `for` loop that reads one `_meta.rds` file at a time, derives the 1-row tibble AND the phase-timing rows in a single pass, then `rm(bundle)`. Peak collation memory: `O(1 bundle + N × ~5 KB rows)` instead of `O(N × ~5-500 KB bundles)`.
5. **Timings** — the standalone `imap(pkg_bundles, ...)` block that built `timings_df` is gone; `timings_rows` is now populated inside the meta-collation pass and flattened with `list_rbind(compact(...))` before the CSV write.

## Byte-equivalence

The `bundle_row` transform (`list_flatten` + wrap `depends`/`suggests`/`rev_deps`/`sys_info` in `list()` + `as_tibble`) is identical to before. Only the source of bundles moved from an in-memory list to sequential `readRDS()` calls. `dplyr::bind_rows(list_of_tibbles)` is order-preserving, so the row order of `pkgs_df0` matches `list.files(assessed, pattern = "_meta.rds$")` (alphabetical). Previously it matched `pkgs` (dep-freq order). If any downstream code depends on the pre-refactor row order, we should hear about it via #91 — but nothing in `val_build()` or `val_decision()` does; `reject_iteration()` keys off `\$pkg`, and `qual_metadata0.rds` is a debugging snapshot.

## Free bonus: crash recovery

Already worked before this PR — noting it in NEWS. Rerun `val_pipeline()` with the same args and `assess_one()`'s cached branch (`!file.exists(pkg_meta_file) | replace`) short-circuits every previously-assessed pkg via its on-disk `_meta.rds`.

## Testing

- `devtools::test(filter = "collate_bundles")` — 20 pass. The empty-`assessed/` guard still fires; the `bundle_row` equivalence tests still pass because the transform is unchanged.
- `devtools::test()` full suite — 659 pass. 2 pre-existing failures in `test-bioc-remote-initial-metrics.R` (unrelated; the config previously commented out `bioc_remote_initial_metrics` and that test hasn't been updated — deserves its own issue).
- `devtools::document()` — no changes required (no exported-signature edits).

## Version + NEWS

Bumped `0.1.15 → 0.1.16`; NEWS entry added under a new `# val.pipeline 0.1.16` heading.

## Suggested next-run knobs

None new. Reuse the same settings from PR #88 / #90:

```r
options(val.pipeline.log_level = "normal")
val_pipeline(..., verbose = "minimal", workers = 6, freeze_opt_repos = TRUE)
```

Memory should be materially lower during collation; watch `htop` around the "Saved assessment records to ..." → "Saved interim pkg metadata to ..." transition to see the peak drop.