### PR TITLE
val_pipeline_report(): disable renv autoloader for the Quarto subprocess (#95)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.17
+Version: 0.1.18
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# val.pipeline 0.1.18
+
+- Fix `val_pipeline_report()` failing on air-gapped PPM hosts with
+  `Error running quarto CLI from R. ... unable to access index for
+  repository https://bioconductor.org/packages/.../PACKAGES`. The
+  Quarto CLI spawns a child Rscript for the render, which was
+  inheriting the parent session's renv activation (`RENV_PROJECT`
+  and/or an activated `renv/activate.R`) and trying to
+  `Bootstrapping renv 1.x.x` -> `Download renv` from every configured
+  repo. On offline hosts the BioC repo download failed and took the
+  whole report render down. `val_pipeline_report()` now wraps the
+  `quarto::quarto_render()` call in `withr::with_envvar()` that sets
+  `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` and unsets `RENV_PROJECT`
+  for the child process. The Quarto child still inherits the
+  parent's `.libPaths()`, so val.pipeline + its imports remain
+  visible from inside the .qmd; we're just skipping the useless
+  bootstrap step. (#95)
+
 # val.pipeline 0.1.17
 
 - Export `write_qualified_pkg_lists()` so operators can regenerate the

--- a/R/val_pipeline_report.R
+++ b/R/val_pipeline_report.R
@@ -318,11 +318,33 @@ val_pipeline_report <- function(
     pipeline_runtime = runtime_str
   )
 
-  quarto::quarto_render(
-    input = qmd_path,
-    output_format = quarto_formats,
-    execute_params = execute_params,
-    quiet = quiet
+  # Quarto spawns a child Rscript for the render. If that child sees an
+  # active renv project (via RENV_PROJECT, an activated renv/activate.R
+  # inherited from the parent session, or an .Rprofile it happens to
+  # walk into), it tries to `Bootstrapping renv 1.x.x` and then
+  # `Download renv` from every configured repo. On air-gapped PPM
+  # hosts, that download hits e.g.
+  # `https://bioconductor.org/packages/3.22/bioc/src/contrib/PACKAGES`,
+  # fails, and takes the whole render down with a confusing
+  # `unable to access index for repository` error that has nothing to
+  # do with the report itself.
+  #
+  # Fix: disable renv's autoloader and drop RENV_PROJECT for the child
+  # process. The Quarto child still inherits the parent's `.libPaths()`
+  # (Rscript honors R_LIBS_* etc.), so val.pipeline + all its imports
+  # remain visible from within the .qmd chunks -- we're just skipping
+  # the useless bootstrap step. See #95.
+  withr::with_envvar(
+    c(
+      RENV_CONFIG_AUTOLOADER_ENABLED = "FALSE",
+      RENV_PROJECT = NA
+    ),
+    quarto::quarto_render(
+      input = qmd_path,
+      output_format = quarto_formats,
+      execute_params = execute_params,
+      quiet = quiet
+    )
   )
 
   # Quarto writes outputs next to the .qmd. Collect and move them.

--- a/tests/testthat/test-val_pipeline_report.R
+++ b/tests/testthat/test-val_pipeline_report.R
@@ -583,3 +583,63 @@ test_that("val_pipeline_report includes Downloads (1yr) row from primary_risk_ca
   expect_true(grepl("Downloads (1yr)", html, fixed = TRUE))
   expect_false(grepl("primary_risk_category", html, fixed = TRUE))
 })
+
+
+test_that("val_pipeline_report disables renv autoloader for the quarto subprocess", {
+  # Regression for #95: the Quarto CLI spawns a child Rscript which,
+  # if it sees an active renv project (RENV_PROJECT env var or an
+  # inherited renv/activate.R), tries to Bootstrap+Download renv from
+  # every configured repo. On air-gapped PPM hosts that fails against
+  # https://bioconductor.org/... and takes the render down. We mask
+  # `quarto_render` in the val.pipeline namespace, capture the env
+  # vars visible from inside that call, and assert the guard is in
+  # place.
+  skip_if_no_quarto()
+
+  qm_path <- withr::local_tempfile(fileext = ".rds")
+  saveRDS(make_fake_qual_metadata(), qm_path)
+
+  # Pre-seed a fake RENV_PROJECT so we can prove it gets cleared.
+  withr::local_envvar(
+    c(RENV_PROJECT = "/fake/renv/project",
+      RENV_CONFIG_AUTOLOADER_ENABLED = NA)
+  )
+
+  captured <- new.env(parent = emptyenv())
+  captured$RENV_PROJECT <- "not-captured-yet"
+  captured$RENV_CONFIG_AUTOLOADER_ENABLED <- "not-captured-yet"
+
+  local_mocked_bindings(
+    quarto_render = function(input, output_format, execute_params, quiet) {
+      captured$RENV_PROJECT <- Sys.getenv("RENV_PROJECT", unset = NA)
+      captured$RENV_CONFIG_AUTOLOADER_ENABLED <-
+        Sys.getenv("RENV_CONFIG_AUTOLOADER_ENABLED", unset = NA)
+      # Fabricate the expected output artifact so the caller doesn't
+      # emit an "expected rendered ... output was not produced" warning.
+      out <- file.path(dirname(input), "summary_template.html")
+      writeLines("<html></html>", out)
+      invisible(NULL)
+    },
+    .package = "quarto"
+  )
+
+  suppressWarnings(
+    val_pipeline_report(
+      qual_metadata_path = qm_path,
+      qual_assessments_path = NA,
+      format = "html",
+      quiet = TRUE
+    )
+  )
+
+  # Inside the quarto_render call, RENV_PROJECT should be unset (NA)
+  # and RENV_CONFIG_AUTOLOADER_ENABLED should be FALSE, regardless of
+  # what the parent session had set.
+  expect_true(is.na(captured$RENV_PROJECT))
+  expect_identical(captured$RENV_CONFIG_AUTOLOADER_ENABLED, "FALSE")
+
+  # And withr should have restored the parent state after the call.
+  expect_identical(Sys.getenv("RENV_PROJECT"), "/fake/renv/project")
+  expect_identical(Sys.getenv("RENV_CONFIG_AUTOLOADER_ENABLED", unset = NA),
+                   NA_character_)
+})


### PR DESCRIPTION
Closes #95.

## Symptom

On an air-gapped PPM host, `val_pipeline()` finishes assessment cleanly and then dies at the very end with:

```
Warning message:
val_pipeline_report() failed: ! Error running quarto CLI from R.
Caused by error in quarto::quarto_render() at val.pipeline/R/val_pipeline_report.R:321:3:
✖ Error returned by quarto CLI.
  # Bootstrapping renv 1.1.5 ---
  - Downloading renv ... Warning: unable to access index for repository
    https://bioconductor.org/packages/3.22/bioc/src/contrib:
    cannot open URL 'https://bioconductor.org/packages/3.22/bioc/src/contrib/PACKAGES'
```

The error message points at Bioconductor, but the actual failure has nothing to do with the report content — it's the render subprocess trying to bootstrap renv.

## Root cause

`quarto::quarto_render()` shells out to the Quarto CLI, which spawns a child Rscript to execute the report's R chunks. That child inherits env vars from the parent val.pipeline session — including `RENV_PROJECT` (val.pipeline itself is developed under renv) and whatever activated `renv/activate.R` was loaded. When `renv/activate.R` sees no renv installed in the child's project library, it tries to **bootstrap** by downloading renv from every entry in `getOption("repos")`. That hits `https://bioconductor.org/packages/3.22/bioc/src/contrib/PACKAGES`, which is unreachable on the offline host, and the download aborts the whole render.

## Fix

Wrap the `quarto_render()` call in `withr::with_envvar()` that sets `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` and unsets `RENV_PROJECT` for the child process. `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE` is renv's canonical short-circuit — it's honored by `renv/activate.R` even if the file gets sourced, so the bootstrap never runs. The Quarto child still inherits the parent's `.libPaths()` (Rscript honors `R_LIBS_*`), so val.pipeline and all its imports remain visible from inside the .qmd chunks; we're just skipping the useless renv bootstrap.

## Why not fix the .qmd / template instead?

The template itself doesn't touch renv — the bootstrap fires from `renv/activate.R` before any user code runs, so a template-level fix wouldn't catch it. The env-var mask has to happen in the parent process at the moment we invoke Quarto.

## Verification

- **New regression test** (`test-val_pipeline_report.R`): uses `testthat::local_mocked_bindings()` to intercept `quarto::quarto_render`, pre-seeds a fake `RENV_PROJECT=/fake/renv/project` in the parent, then captures `Sys.getenv()` from inside the mocked call. Asserts `RENV_PROJECT` is `NA` and `RENV_CONFIG_AUTOLOADER_ENABLED == "FALSE"` during the render, and that both env vars are correctly restored to their parent values after the call returns.
- `devtools::test(filter = "val_pipeline_report")` — all 55 tests pass (previous 54 + 1 new).

## Files

- `R/val_pipeline_report.R` — wrap `quarto::quarto_render()` in `withr::with_envvar()` with an explanatory comment block pointing at #95.
- `tests/testthat/test-val_pipeline_report.R` — new regression test at the tail.
- `DESCRIPTION` — 0.1.17 → 0.1.18.
- `NEWS.md` — new entry under 0.1.18.