### PR TITLE
Mirror .libPaths() into R_LIBS_SITE so rcmdcheck/covr subprocesses see the rv library (#99)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.19
+Version: 0.1.20
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# val.pipeline 0.1.20
+
+- `val_build()` and `val_pipeline()` now mirror the parent R session's
+  `.libPaths()` into the `R_LIBS_SITE` environment variable for the
+  duration of the assessment loop, so subprocesses spawned by
+  riskmetric — `rcmdcheck::rcmdcheck()` (for the `r_cmd_check`
+  metric), `covr::package_coverage()` (for `covr_coverage`), etc. —
+  see the same library search order as the parent. A fresh R
+  subprocess does NOT inherit an interactive `.libPaths()` from the
+  parent, so before this fix, users who pointed `.libPaths()` at an
+  rv-provisioned library (the recommended flow after PR #67 introduced
+  `write_pipeline_toml()`) saw ~65% of packages come back with
+  `r_cmd_check_errors` and `r_cmd_check_warnings` as `NA` because
+  R CMD check couldn't find their deps. The mirror is restored on
+  function exit via `withr::local_envvar()`. Controlled by a new
+  `propagate_libpaths` argument on both `val_build()` and
+  `val_pipeline()` (default `TRUE`, sourced from
+  `getOption("val.pipeline.propagate_libpaths", TRUE)` so it can be
+  disabled session-wide). (#99)
+
 # val.pipeline 0.1.19
 
 - Add `val_timings_summary()`: exported standalone analysis helper for

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -176,7 +176,7 @@ val_build <- function(
     withr::local_envvar(c(R_LIBS_SITE = new_r_libs_site))
     val_msg(paste0("--> Mirrored .libPaths() into R_LIBS_SITE for ",
                    "subprocess visibility (r_cmd_check, covr_coverage, ...).\n"),
-            min_level = "verbose")
+            min_level = "normal")
   }
 
   # Route pull_config() at any depth to the user-supplied config, if any.

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -86,6 +86,24 @@
 #'   instead of being short-circuited. Requires the optional `{future}`
 #'   and `{future.apply}` packages when `workers > 1`.
 #'
+#' @param propagate_libpaths Logical(1). When `TRUE` (default), mirrors
+#'   the current session's `.libPaths()` into the `R_LIBS_SITE`
+#'   environment variable for the duration of the assessment loop, so
+#'   subprocesses spawned by `riskmetric` (e.g. `rcmdcheck::rcmdcheck()`
+#'   for the `r_cmd_check` metric, `covr::package_coverage()` for
+#'   `covr_coverage`) see the same library search order as the parent R
+#'   session. Without this, an interactive `.libPaths()` call in the
+#'   parent (e.g. to point at an rv-provisioned library like
+#'   `/data/pm/riskassessments/R_.../rv/library/.../`) does not reach
+#'   any child R process, so R CMD check fails to locate dependencies
+#'   and `r_cmd_check_errors` / `r_cmd_check_warnings` come back as
+#'   `NA` for every package with a non-base dependency. Restored on
+#'   function exit. Defaults to
+#'   `getOption("val.pipeline.propagate_libpaths", TRUE)`; set that
+#'   option to `FALSE` (or pass `propagate_libpaths = FALSE`) to opt
+#'   out when an operator needs the child library search to stay
+#'   isolated from the parent for some reason. See #99.
+#'
 #' @export
 #' 
 val_build <- function(
@@ -103,7 +121,8 @@ val_build <- function(
     verbose = NULL,
     prep = NULL,
     config_path = NULL,
-    workers = 1L
+    workers = 1L,
+    propagate_libpaths = getOption("val.pipeline.propagate_libpaths", TRUE)
     ){
   
   #
@@ -140,6 +159,25 @@ val_build <- function(
   apply_verbose(verbose)
   configure_bioc_repositories_if_requested(quiet = TRUE)
   configure_riskmetric_offline_if_requested(quiet = TRUE)
+
+  # Mirror the parent session's .libPaths() into R_LIBS_SITE so every
+  # subprocess spawned by riskmetric (rcmdcheck::rcmdcheck for the
+  # r_cmd_check metric, covr::package_coverage for covr_coverage, ...)
+  # sees the same library search order. A fresh R subprocess does NOT
+  # inherit interactive .libPaths() from the parent — it rebuilds its
+  # search order from R_LIBS_SITE / R_LIBS_USER / R_LIBS + site
+  # defaults. Without this mirror, an operator who pointed .libPaths()
+  # at an rv-provisioned library (typical for the val.pipeline "install
+  # via rv" flow) sees ~65% of packages come back with r_cmd_check_
+  # errors/_warnings == NA because R CMD check can't find their deps.
+  # Restored on exit via withr::local_envvar. See #99.
+  if (isTRUE(propagate_libpaths)) {
+    new_r_libs_site <- paste(.libPaths(), collapse = .Platform$path.sep)
+    withr::local_envvar(c(R_LIBS_SITE = new_r_libs_site))
+    val_msg(paste0("--> Mirrored .libPaths() into R_LIBS_SITE for ",
+                   "subprocess visibility (r_cmd_check, covr_coverage, ...).\n"),
+            min_level = "verbose")
+  }
 
   # Route pull_config() at any depth to the user-supplied config, if any.
   old_cfg <- options()["val.pipeline.config_path"]

--- a/R/val_pipeline.R
+++ b/R/val_pipeline.R
@@ -68,6 +68,13 @@
 #'   was actually executed. `val_date` still governs the output
 #'   directory name and every `val_date` field written to metadata.
 #'   See #89.
+#' @param propagate_libpaths Logical(1). Passed through to [val_build()];
+#'   see there for the full rationale. In short: when `TRUE` (default),
+#'   mirrors the current session's `.libPaths()` into `R_LIBS_SITE` so
+#'   `rcmdcheck` / `covr` / any other riskmetric subprocess sees the
+#'   same library search order as the parent — critical when the
+#'   operator has pointed `.libPaths()` at an rv-provisioned library.
+#'   See #99.
 #' @return A list containing the validation directory and a data frame of
 #'   package assessments.
 #'
@@ -92,7 +99,8 @@ val_pipeline <- function(
   prep = NULL,
   config_path = NULL,
   workers = 1L,
-  freeze_opt_repos = FALSE
+  freeze_opt_repos = FALSE,
+  propagate_libpaths = getOption("val.pipeline.propagate_libpaths", TRUE)
   ){
 
   # Assess args
@@ -159,7 +167,8 @@ val_pipeline <- function(
     opt_repos       = prep$opt_repos,
     prep            = prep,
     config_path     = config_path,
-    workers         = workers
+    workers         = workers,
+    propagate_libpaths = propagate_libpaths
   )
   
   

--- a/man/val_build.Rd
+++ b/man/val_build.Rd
@@ -18,7 +18,8 @@ val_build(
   verbose = NULL,
   prep = NULL,
   config_path = NULL,
-  workers = 1L
+  workers = 1L,
+  propagate_libpaths = getOption("val.pipeline.propagate_libpaths", TRUE)
 )
 }
 \arguments{
@@ -87,6 +88,24 @@ package-report accuracy is unaffected — the only tradeoff is that
 dependents of failed packages spend CPU time being assessed
 instead of being short-circuited. Requires the optional \code{{future}}
 and \code{{future.apply}} packages when \code{workers > 1}.}
+
+\item{propagate_libpaths}{Logical(1). When \code{TRUE} (default), mirrors
+the current session's \code{.libPaths()} into the \code{R_LIBS_SITE}
+environment variable for the duration of the assessment loop, so
+subprocesses spawned by \code{riskmetric} (e.g. \code{rcmdcheck::rcmdcheck()}
+for the \code{r_cmd_check} metric, \code{covr::package_coverage()} for
+\code{covr_coverage}) see the same library search order as the parent R
+session. Without this, an interactive \code{.libPaths()} call in the
+parent (e.g. to point at an rv-provisioned library like
+\verb{/data/pm/riskassessments/R_.../rv/library/.../}) does not reach
+any child R process, so R CMD check fails to locate dependencies
+and \code{r_cmd_check_errors} / \code{r_cmd_check_warnings} come back as
+\code{NA} for every package with a non-base dependency. Restored on
+function exit. Defaults to
+\code{getOption("val.pipeline.propagate_libpaths", TRUE)}; set that
+option to \code{FALSE} (or pass \code{propagate_libpaths = FALSE}) to opt
+out when an operator needs the child library search to stay
+isolated from the parent for some reason. See #99.}
 }
 \value{
 A list containing:

--- a/man/val_pipeline.Rd
+++ b/man/val_pipeline.Rd
@@ -18,7 +18,8 @@ val_pipeline(
   prep = NULL,
   config_path = NULL,
   workers = 1L,
-  freeze_opt_repos = FALSE
+  freeze_opt_repos = FALSE,
+  propagate_libpaths = getOption("val.pipeline.propagate_libpaths", TRUE)
 )
 }
 \arguments{
@@ -92,6 +93,14 @@ folder (\verb{R_<ver>/<YYYYMMDD>/}) to reflect the date the analysis
 was actually executed. \code{val_date} still governs the output
 directory name and every \code{val_date} field written to metadata.
 See #89.}
+
+\item{propagate_libpaths}{Logical(1). Passed through to \code{\link[=val_build]{val_build()}};
+see there for the full rationale. In short: when \code{TRUE} (default),
+mirrors the current session's \code{.libPaths()} into \code{R_LIBS_SITE} so
+\code{rcmdcheck} / \code{covr} / any other riskmetric subprocess sees the
+same library search order as the parent — critical when the
+operator has pointed \code{.libPaths()} at an rv-provisioned library.
+See #99.}
 }
 \value{
 A list containing the validation directory and a data frame of

--- a/tests/testthat/test-propagate-libpaths.R
+++ b/tests/testthat/test-propagate-libpaths.R
@@ -1,0 +1,77 @@
+test_that("val_build() mirrors .libPaths() into R_LIBS_SITE during the run", {
+  # Regression for #99: rcmdcheck / covr subprocesses spawned by
+  # riskmetric can't see the parent's .libPaths() unless R_LIBS_SITE
+  # (or R_LIBS_USER / R_LIBS) is set. val_build() should mirror
+  # .libPaths() into R_LIBS_SITE for the duration of the call and
+  # restore the previous value on exit.
+  #
+  # We don't want to actually spin up a full val_build() here (way
+  # too heavy for a unit test), so we drive the helper block directly
+  # with the same idiom val_build() uses. That gives us a truthful
+  # test of the mirroring / restore contract without the assessment
+  # loop noise.
+  fake_lib <- withr::local_tempdir()
+
+  withr::local_envvar(c(R_LIBS_SITE = "/preexisting/site"))
+  withr::with_libpaths(
+    c(fake_lib, .libPaths()),
+    action = "prefix",
+    {
+      # Simulate the same block val_build() runs:
+      run <- function() {
+        new_r_libs_site <- paste(.libPaths(), collapse = .Platform$path.sep)
+        withr::local_envvar(c(R_LIBS_SITE = new_r_libs_site))
+        Sys.getenv("R_LIBS_SITE")
+      }
+      captured <- run()
+
+      # Inside run(), R_LIBS_SITE should start with the fake_lib we
+      # prepended via with_libpaths.
+      expect_true(startsWith(captured, fake_lib))
+
+      # And after run() returns, R_LIBS_SITE must be restored.
+      expect_identical(Sys.getenv("R_LIBS_SITE"), "/preexisting/site")
+    }
+  )
+})
+
+
+test_that("val_build(propagate_libpaths = FALSE) leaves R_LIBS_SITE untouched", {
+  withr::local_envvar(c(R_LIBS_SITE = "/preexisting/site"))
+  # Simulate the opt-out branch: the if(isTRUE(propagate_libpaths))
+  # block is skipped so R_LIBS_SITE never gets rewritten.
+  propagate_libpaths <- FALSE
+  if (isTRUE(propagate_libpaths)) {
+    new_r_libs_site <- paste(.libPaths(), collapse = .Platform$path.sep)
+    withr::local_envvar(c(R_LIBS_SITE = new_r_libs_site))
+  }
+  expect_identical(Sys.getenv("R_LIBS_SITE"), "/preexisting/site")
+})
+
+
+test_that("val_build(propagate_libpaths = ...) default honors val.pipeline.propagate_libpaths option", {
+  # The default expression is
+  #   getOption("val.pipeline.propagate_libpaths", TRUE)
+  # so an operator can globally opt out via options().
+  fn <- formals(val_build)
+  default_expr <- fn$propagate_libpaths
+  expect_identical(
+    as.character(default_expr[[1]]),
+    "getOption"
+  )
+  expect_identical(default_expr[[2]], "val.pipeline.propagate_libpaths")
+  expect_identical(default_expr[[3]], TRUE)
+})
+
+
+test_that("val_pipeline() forwards propagate_libpaths to val_build()", {
+  # Signature check: val_pipeline() must expose the arg (so callers
+  # can pass it through) and default to the same getOption() lookup
+  # val_build() uses, so a session-wide option controls both.
+  fn <- formals(val_pipeline)
+  expect_true("propagate_libpaths" %in% names(fn))
+  default_expr <- fn$propagate_libpaths
+  expect_identical(as.character(default_expr[[1]]), "getOption")
+  expect_identical(default_expr[[2]], "val.pipeline.propagate_libpaths")
+  expect_identical(default_expr[[3]], TRUE)
+})


### PR DESCRIPTION
Closes #99.

## Symptom

In an rv-provisioned run, ~65% of assessed packages come back with `r_cmd_check_errors` and `r_cmd_check_warnings` as `NA` — even though the operator did the right thing at session start:

```r
.libPaths(c("/data/pm/riskassessments/R_4.5.2/20260721/rv/library/4.5/x86_64/redhat9",
            .libPaths()))
```

## Root cause

`riskmetric::assess_r_cmd_check.pkg_source` calls `rcmdcheck::rcmdcheck()`, which shells out to a fresh `R CMD check` subprocess. **That subprocess is a new R process** — it does NOT inherit interactive `.libPaths()` from the parent. The child rebuilds its library search order entirely from `R_LIBS_SITE`, `R_LIBS_USER`, `R_LIBS` + the site defaults. So the rv library the parent sees at `.libPaths()[1]` is invisible to the child, install fails, R CMD check errors at 'checking package dependencies', and `val_pkg` maps the resulting `pkg_metric_error` to `NA_real_` (`R/utils.R:719-720`).

Same gotcha silently affects any other riskmetric metric that spawns an R subprocess — most notably `covr::package_coverage()` for `covr_coverage`.

## Fix

`val_build()` now mirrors the parent's `.libPaths()` into `R_LIBS_SITE` via `withr::local_envvar()` for the duration of the assessment loop. Every child R process spawned during that window inherits the same library search order as the parent. Restored on function exit.

`val_pipeline()` gets the same `propagate_libpaths` argument and forwards it to `val_build()`, so the pipeline entry point picks up the fix automatically.

## Controls

- New `propagate_libpaths` arg on both `val_build()` and `val_pipeline()`.
- Defaults to `getOption("val.pipeline.propagate_libpaths", TRUE)` — so operators can globally opt out with `options(val.pipeline.propagate_libpaths = FALSE)` when they specifically want the child library search to stay isolated from the parent.

## Why `R_LIBS_SITE` and not `R_LIBS_USER` / `R_LIBS`

- `R_LIBS_SITE` is prepended before the stock site path but after `R_LIBS_USER`, which matches the intent (rv library is a shared provisioned artifact, not a per-user one, and it should win over the stock site defaults).
- Setting `R_LIBS` would clobber the child's default search order entirely. `R_LIBS_SITE` is a surgical override.
- rv itself doesn't rely on `R_LIBS_SITE` being any particular value, so we don't stomp on its own bookkeeping.

## Verification

- `devtools::test(filter = "propagate-libpaths")` — 4 targeted tests pass:
  1. Mirror block rewrites `R_LIBS_SITE` during the call AND restores the pre-existing value on exit (uses `withr::with_libpaths()` + `withr::local_envvar()` to simulate the val_build() body without spinning up a full assessment loop).
  2. `propagate_libpaths = FALSE` opt-out branch leaves `R_LIBS_SITE` untouched.
  3. `val_build` default expression is `getOption("val.pipeline.propagate_libpaths", TRUE)`.
  4. `val_pipeline` exposes the same arg with the same default.
- Full `devtools::test()` locally — no new failures introduced.

## User-facing behavior change

None for operators who don't hand-mutate `.libPaths()` — `R_LIBS_SITE` gets the same set of paths they were already going to hit. The change is a **strict superset** of what the child search saw before, so previously-successful assessments stay successful, and previously-failing ones (dep-lookup failures) now succeed.

## Files

- `R/val_build.R` — new `propagate_libpaths` arg, mirroring block after arg validation, matching roxygen.
- `R/val_pipeline.R` — new `propagate_libpaths` arg, forwarded to `val_build()`, roxygen entry.
- `man/val_build.Rd`, `man/val_pipeline.Rd` — regenerated.
- `tests/testthat/test-propagate-libpaths.R` — new, 4 tests.
- `DESCRIPTION` — 0.1.19 → 0.1.20.
- `NEWS.md` — new entry under 0.1.20.

## Follow-up for you (Aaron) on the current run

You don't have to wait for this to merge to unblock your in-flight run — you can get the same behavior by adding one line at session start:

```r
Sys.setenv(R_LIBS_SITE = paste(.libPaths(), collapse = .Platform$path.sep))
```

Then re-run against the packages that returned NA (`replace = FALSE` will skip already-successful ones).