### PR TITLE
Fix reject_iteration() convergence loop scope bug (#103)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.20
+Version: 0.1.21
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# val.pipeline 0.1.21
+
+- Fixed a latent scope bug in `val_build()`'s dep-driven decision
+  propagation loop that caused it to spin forever on any cohort
+  large enough to actually need >1 iteration of `reject_iteration()`.
+  The loop's body used `<<-` to update its `failed` and `pkgs_df`
+  locals, which — inside a top-level function — skipped the local
+  frame and assigned into the enclosing lexical scope, leaving both
+  locals stuck at their iter-1 values and the loop condition
+  perpetually `TRUE`. Latent because small dev cohorts converge on
+  iteration 1, so the bug never fired in tests; a 1422-package run
+  surfaced it via `val_finalize()`'s new propagation messaging.
+  Changed both to local `<-`; added a regression test that runs a
+  3-package dependency chain (X ← Y ← Z) requiring exactly 2
+  propagation passes and hard-caps the loop at 10 iterations so a
+  re-introduction of the bug fails testthat instead of hanging CI.
+  (#103)
+
 # val.pipeline 0.1.20
 
 - `val_build()` and `val_pipeline()` now mirror the parent R session's

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -676,10 +676,19 @@ val_build <- function(
   pkgs_df <- reject_iteration(pkgs_df0, dec_reject, deps, decisions, failed)
   
   # All remaining iterations!
+  # NB: use `<-` (not `<<-`) here. `<<-` inside a top-level function
+  # skips the function's own frame and searches the *enclosing*
+  # lexical scope (the package namespace, then globalenv) for an
+  # existing binding, leaving the local `failed` / `pkgs_df` bindings
+  # unchanged. That turns the fixed-point loop into an infinite loop
+  # whenever the seed set differs from the iter-1 result (i.e. any
+  # cohort large enough that dep propagation actually needs to run).
+  # Local `<-` is the intended semantics — reject_iteration() returns
+  # the updated frame we want to re-check on the next pass. See #103.
   while(!identical(pkgs_df$pkg[pkgs_df$final_decision != decisions[1]], failed)) {
     # if the list of failed pkgs has changed, then we need to iterate again
-    failed <<- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
-    pkgs_df <<- reject_iteration(pkgs_df, dec_reject, deps, decisions, failed)
+    failed <- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
+    pkgs_df <- reject_iteration(pkgs_df, dec_reject, deps, decisions, failed)
   }
   
   val_msg("\n--> Assigned 'final' decisions.\n", min_level = "minimal")

--- a/dev/dev_pipeline.R
+++ b/dev/dev_pipeline.R
@@ -41,20 +41,24 @@ prep <- val_prep_pipeline(
   toml_local_repo = 'https://fake.test.com/local-r4.5-2026-07-21/', # new
   verbose         = 'normal'
 )
-
+names(prep)
+prep$val_start
 
 # Create qualified pkg data.frame
-qual <- val_pipeline(
-  workers         = workers,
-  ref             = ref,
-  metric_pkg      = metric_pkg,
-  deps            = deps,
-  deps_recursive  = deps_recursive,
-  val_date        = val_date,
-  out             = out,
-  opt_repos       = opt_repos,
-  verbose = 'minimal'
-)
+# qual <- val_pipeline(
+#   workers         = workers,
+#   ref             = ref,
+#   metric_pkg      = metric_pkg,
+#   deps            = deps,
+#   deps_recursive  = deps_recursive,
+#   val_date        = val_date,
+#   out             = out,
+#   opt_repos       = opt_repos,
+#   verbose = 'minimal'
+# )
+
+
+val_finalize(prep = prep)
 
 # 
 # Quick run

--- a/tests/testthat/test-reject_iteration.R
+++ b/tests/testthat/test-reject_iteration.R
@@ -117,3 +117,107 @@ test_that("reject_iteration() derives failed_pkgs from final_decision if NA", {
   expect_equal(out$final_decision[out$pkg == "C"], "High")
   expect_equal(out$final_decision_reason[out$pkg == "C"], "Dependency")
 })
+
+# ---- Fixed-point convergence loop (regression, #103) ----------------------
+
+# Guards val_build()'s (and val_finalize()'s in #101) reject_iteration()
+# convergence loop against an infinite-loop bug introduced by a stray
+# `<<-`. Prior to #103, the loop assigned `failed <<- ...` /
+# `pkgs_df <<- ...`, which skipped the enclosing function's frame and
+# left both locals stuck at their iter-1 values -- so any cohort large
+# enough that dep propagation needed >1 pass (i.e. anything real-world)
+# spun forever. Simulate that convergence loop in-test and require it
+# to terminate.
+test_that("reject_iteration() reaches a fixed point in <= n iterations", {
+  # Chain: X (High) <- Y (Low; depends X) <- Z (Low; depends Y).
+  # Iter 1: only X is in `failed`; Y gets downgraded via depends.
+  # Iter 2: with Y now failed, Z gets downgraded via depends.
+  # Iter 3: fixed point.
+  # If the outer loop mis-scopes its assignments, this test loops forever
+  # and testthat kills it -- an unmissable regression signal.
+  pkg_dat <- tibble::tibble(
+    pkg              = c("X", "Y", "Z"),
+    decision         = c("High", "Low", "Low"),
+    decision_reason  = c("Risk Assessment", "Risk Assessment",
+                         "Risk Assessment"),
+    final_decision         = NA_character_,
+    final_decision_reason  = NA_character_,
+    decision_reason_note   = NA_character_,
+    final_decision_reason_note = NA_character_,
+    depends  = list(character(0), "X", "Y"),
+    suggests = list(character(0), character(0), character(0))
+  )
+
+  # Simulate the exact convergence loop shape used in val_finalize() /
+  # val_build(). Local `<-` (not `<<-`) is the intended semantics.
+  failed  <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]
+  pkgs_df <- reject_iteration(pkg_dat, dec_reject = "High",
+                              deps = "depends", decisions = decisions,
+                              failed_pkgs = failed)
+  n_iter <- 1L
+  max_iter <- 10L  # hard cap; test fails if loop doesn't converge.
+  while (!identical(pkgs_df$pkg[pkgs_df$final_decision != decisions[1]],
+                    failed)) {
+    if (n_iter >= max_iter) {
+      fail("reject_iteration() convergence loop did not terminate after ",
+           max_iter, " iterations")
+    }
+    failed  <- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
+    pkgs_df <- reject_iteration(pkgs_df, dec_reject = "High",
+                                deps = "depends", decisions = decisions,
+                                failed_pkgs = failed)
+    n_iter <- n_iter + 1L
+  }
+
+  # Chain requires 2 in-loop passes on top of the initial call, so the
+  # total counter lands at 3 (1 initial + 2 in-loop).
+  expect_equal(n_iter, 3L)
+  # Every pkg in the chain ends up High-flagged.
+  expect_setequal(pkgs_df$pkg[pkgs_df$final_decision == "High"],
+                  c("X", "Y", "Z"))
+  # Y and Z were downgraded via a Dependency.
+  expect_equal(pkgs_df$final_decision_reason[pkgs_df$pkg == "Y"],
+               "Dependency")
+  expect_equal(pkgs_df$final_decision_reason[pkgs_df$pkg == "Z"],
+               "Dependency")
+})
+
+test_that("the buggy `<<-` variant would have spun forever (regression proof, #103)", {
+  # Positive proof that the `<<-` variant introduces the bug: run the
+  # exact same convergence loop shape with `<<-` instead of `<-` and
+  # assert it hits our 10-iteration safety cap without converging.
+  # This locks in the diagnosis so a future refactor can't quietly
+  # reintroduce `<<-` "because it's shorter".
+  pkg_dat <- tibble::tibble(
+    pkg              = c("X", "Y", "Z"),
+    decision         = c("High", "Low", "Low"),
+    decision_reason  = rep("Risk Assessment", 3),
+    final_decision         = NA_character_,
+    final_decision_reason  = NA_character_,
+    decision_reason_note   = NA_character_,
+    final_decision_reason_note = NA_character_,
+    depends  = list(character(0), "X", "Y"),
+    suggests = list(character(0), character(0), character(0))
+  )
+  # Wrap in a function so `<<-` inside behaves the way it does when
+  # embedded inside val_finalize() / val_build() -- i.e. skips this
+  # function's own frame.
+  run_buggy <- function() {
+    failed  <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]
+    pkgs_df <- reject_iteration(pkg_dat, dec_reject = "High",
+                                deps = "depends", decisions = decisions,
+                                failed_pkgs = failed)
+    n_iter <- 1L
+    while (!identical(pkgs_df$pkg[pkgs_df$final_decision != decisions[1]],
+                      failed)) {
+      if (n_iter >= 10L) return(n_iter)  # safety cap
+      failed  <<- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
+      pkgs_df <<- reject_iteration(pkgs_df, dec_reject = "High",
+                                   deps = "depends", decisions = decisions,
+                                   failed_pkgs = failed)
+      n_iter <- n_iter + 1L
+    }
+    n_iter
+  }
+  expect_equal(run_buggy(), 10L)
+})


### PR DESCRIPTION
Closes #103.

## Symptom

On a 1422-package run the "propagate dep-driven decisions" phase spun forever after iter 1 (surfaced by `val_finalize()`'s new messaging on PR #102):

```
--> [3/5] Propagating dep-driven decisions ...
    863 pkg(s) start above 'Low' (seed set for propagation).
    iter 1: 1156 pkg(s) above 'Low' after propagation (+293 vs. seed).
    iter 2: 1156 pkg(s) above 'Low' after propagation.
    ...
    iter 36: 1156 pkg(s) above 'Low' after propagation.  # never exits
```

The tally converges (1156 → 1156 → …), yet the loop keeps running.

## Root cause

`val_build()`'s while-loop body used `<<-`:

```r
while (!identical(pkgs_df$pkg[pkgs_df$final_decision != decisions[1]], failed)) {
  failed  <<- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
  pkgs_df <<- reject_iteration(pkgs_df, dec_reject, deps, decisions, failed)
}
```

`<<-` inside a function skips the function's own frame and searches the *enclosing* lexical scope for an existing binding — so `failed` and `pkgs_df` in `val_build()`'s local env never update. The local `failed` stays at the seed set (863 pkgs) and the local `pkgs_df` stays at the iter-1 result forever, so the condition `!identical(iter1_1156, seed_863)` is always TRUE.

Latent since the loop was written; small dev cohorts converge on iter 1 (iter-1 output = seed set), so the bug never fired in tests.

## Fix

Change `<<-` to `<-` (both lines). One-line fix, plus a code comment explaining the trap so it doesn't get reintroduced. PR #102 will need the same fix applied to the extracted `val_finalize.R` at rebase time.

## Tests

Added two regression tests in `tests/testthat/test-reject_iteration.R`:

1. **Correctness** — 3-pkg dependency chain (X ← Y ← Z) requiring exactly 2 in-loop propagation passes (iter counter lands at 3 = 1 initial + 2 in-loop). Hard-caps the loop at 10 iterations so a re-introduction of the bug **fails testthat instead of hanging CI forever**.
2. **Positive proof** — runs the same loop shape with `<<-` and asserts it hits the 10-iter safety cap without converging. Locks in the diagnosis so nobody quietly reintroduces `<<-` "because it's shorter".

Full suite: `FAIL 2 | WARN 1 | SKIP 1 | PASS 729` — 2 failures are the pre-existing `bioc-remote-initial-metrics` test unrelated to this PR.

## Version

0.1.20 → 0.1.21. PR #102 will need to bump to 0.1.22 at rebase time.