### PR TITLE
Add optional reverse-dep expansion to resolve_pkg_tree() and callers (#105)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.21
+Version: 0.1.22
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# val.pipeline 0.1.22
+
+- Added optional reverse-dependency expansion to `resolve_pkg_tree()`,
+  surfaced via new `rev_deps` / `rev_deps_recursive` args on
+  `val_pipeline()`, `val_prep_pipeline()`, and `val_build()`. When
+  set, the seed set is first expanded with the reverse deps of the
+  supplied packages (via `tools::package_dependencies(reverse = TRUE)`)
+  before forward-dep expansion runs, so re-assessing a remediated
+  package (e.g. `duckdb` flipped from High to Low) can also re-run
+  everything that previously failed *because* it depended on that
+  package. Defaults preserve pre-existing behaviour (`rev_deps = NULL`,
+  `rev_deps_recursive = FALSE`). (#105)
+
 # val.pipeline 0.1.21
 
 - Extracted the collation + wrap-up tail of `val_build()` into a new

--- a/R/resolve_pkg_tree.R
+++ b/R/resolve_pkg_tree.R
@@ -23,6 +23,20 @@
 #'   `pkg_names` as-is".
 #' @param deps_recursive Logical. Whether dependency expansion is
 #'   recursive. Passed straight through.
+#' @param rev_deps One of `"depends"`, `"suggests"`,
+#'   `c("depends","suggests")`, or `NULL` (default). When non-`NULL`,
+#'   the seed set is first expanded with its **reverse** dependencies
+#'   (via `tools::package_dependencies(reverse = TRUE, which = ...)`)
+#'   before forward-dep expansion runs. Use this when re-assessing a
+#'   remediated package (e.g. `duckdb` flipped from High to Low) and
+#'   you want everything that previously failed *because* it depended
+#'   on that pkg to be re-assessed too. `NULL` (default) preserves the
+#'   pre-#105 behaviour of forward-only expansion.
+#' @param rev_deps_recursive Logical, default `FALSE`. Whether
+#'   reverse-dep expansion walks the whole transitive tree. Default is
+#'   `FALSE` because rev-dep trees explode fast (a foundational pkg
+#'   like `Rcpp` has thousands of transitive dependents); flip to
+#'   `TRUE` deliberately.
 #' @param avail_pkgs Optional data frame from
 #'   `as.data.frame(available.packages())`. When `NULL`, one is
 #'   fetched via `utils::available.packages()`. Callers that already
@@ -47,10 +61,49 @@ resolve_pkg_tree <- function(
   pkg_names,
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   avail_pkgs = NULL
 ) {
   if (is.null(avail_pkgs)) {
     avail_pkgs <- utils::available.packages() |> as.data.frame()
+  }
+
+  # Translate the "depends" / "suggests" / c("depends","suggests")
+  # shorthand into the enum tools::package_dependencies() expects. The
+  # same mapping applies to both forward and reverse expansion so the
+  # two knobs feel symmetric to the caller.
+  which_from_arg <- function(x) {
+    x_low <- tolower(x)
+    if (all(c("depends", "suggests") %in% x_low)) {
+      out <- "most"
+    } else if (identical(x_low, "depends")) {
+      out <- "strong"
+    } else if (identical(x_low, "suggests")) {
+      out <- "Suggests"
+    } else {
+      out <- NA_character_
+    }
+    if (!isTRUE(out %in% c("most", "strong", "Suggests")))
+      stop("problem with 'which_deps'")
+    out
+  }
+
+  # ---- Reverse-dep expansion (optional) ----
+  # Runs BEFORE forward-dep expansion so any deps of the rev-deps get
+  # picked up by the forward pass. Only fires when the caller supplied
+  # a seed set — expanding rev-deps of `NULL` (i.e. all of CRAN) is
+  # meaningless. See #105.
+  if (!is.null(pkg_names) && !is.null(rev_deps)) {
+    rev_which <- which_from_arg(rev_deps)
+    rev_tree <- tools::package_dependencies(
+      packages  = pkg_names,
+      which     = rev_which,
+      recursive = rev_deps_recursive,
+      reverse   = TRUE
+    )
+    pkg_names <- unique(c(pkg_names,
+                          unlist(rev_tree, use.names = FALSE)))
   }
 
   if (is.null(pkg_names)) {
@@ -58,21 +111,14 @@ resolve_pkg_tree <- function(
     # currently available from the configured repos.
     pkgs <- avail_pkgs$Package
   } else if (is.null(deps)) {
-    # No expansion requested; treat pkg_names as the terminal set.
+    # No expansion requested; treat pkg_names (already rev-dep-expanded
+    # above if requested) as the terminal set.
     full_dep_tree <- pkg_names
     pkgs <- avail_pkgs |>
       dplyr::filter(Package %in% full_dep_tree) |>
       dplyr::pull(Package)
   } else {
-    deps_low <- tolower(deps)
-    which_deps <- dplyr::case_when(
-      all(c("depends", "suggests") %in% deps_low) ~ "most",
-      deps_low == "depends"  ~ "strong",
-      deps_low == "suggests" ~ "Suggests",
-      .default = NULL
-    )[1]
-    if (!which_deps %in% c("most", "strong", "Suggests"))
-      stop("problem with 'which_deps'")
+    which_deps <- which_from_arg(deps)
 
     dep_tree <- tools::package_dependencies(
       packages  = pkg_names,

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -30,6 +30,16 @@
 #'   assessed without their dependencies.
 #' @param deps_recursive Logical indicating whether to include dependencies
 #'   recursively. Default is TRUE.
+#' @param rev_deps Character or NULL. Types of **reverse** dependencies
+#'   to fold into the seed set before forward-dep expansion runs.
+#'   Same shorthand as `deps` (`"depends"`, `"suggests"`, or both).
+#'   `NULL` (default) means no rev-dep expansion. Only consulted when
+#'   `prep = NULL`; a supplied `prep` already carries a resolved
+#'   package tree.
+#' @param rev_deps_recursive Logical. Whether reverse-dep expansion
+#'   walks the transitive tree. Default is `FALSE` because rev-dep
+#'   trees can explode (foundational pkgs like `Rcpp` have thousands
+#'   of transitive dependents). Ignored when `rev_deps = NULL`.
 #' @param val_date Date object or character string representing the date of the
 #'   validation build. Default is the current date (Sys.Date()).
 #' @param out Character string specifying the output directory for the
@@ -133,6 +143,8 @@ val_build <- function(
     metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
     deps = c("depends", "suggests")[1], # deps = c("depends"), deps = NULL
     deps_recursive = TRUE,
+    rev_deps = NULL,
+    rev_deps_recursive = FALSE,
     val_date = Sys.Date(),
     out = 'riskassessment',
     replace = FALSE,
@@ -256,9 +268,11 @@ val_build <- function(
     if (!is.null(prep$opt_repos)) opt_repos <- prep$opt_repos
   } else {
     tree       <- resolve_pkg_tree(
-      pkg_names      = pkg_names,
-      deps           = deps,
-      deps_recursive = deps_recursive
+      pkg_names          = pkg_names,
+      deps               = deps,
+      deps_recursive     = deps_recursive,
+      rev_deps           = rev_deps,
+      rev_deps_recursive = rev_deps_recursive
     )
     pkgs       <- tree$pkgs
     vers       <- tree$vers

--- a/R/val_pipeline.R
+++ b/R/val_pipeline.R
@@ -18,6 +18,19 @@
 #'   "depends". Options include "depends", "suggests", or NULL.
 #' @param deps_recursive Logical. Whether to consider dependencies recursively.
 #'   Default is TRUE.
+#' @param rev_deps Character or NULL. Types of **reverse** dependencies
+#'   to fold into the seed set before forward-dep expansion runs.
+#'   Same shorthand as `deps` (`"depends"` = Depends/Imports/LinkingTo,
+#'   `"suggests"` = Suggests, `c("depends","suggests")` = both). `NULL`
+#'   (default) preserves the pre-#105 behaviour of no rev-dep
+#'   expansion. Use this when re-assessing a remediated package (e.g.
+#'   `duckdb` flipped from High to Low) so every pkg that previously
+#'   failed *because* it depended on that pkg is re-assessed too.
+#' @param rev_deps_recursive Logical. Whether reverse-dep expansion
+#'   walks the whole transitive tree. Default is `FALSE` because
+#'   rev-dep trees explode fast (a foundational pkg like `Rcpp` has
+#'   thousands of transitive dependents); flip to `TRUE` deliberately.
+#'   Ignored when `rev_deps = NULL`.
 #' @param val_date Date. The date for validation. Default is the current date.
 #' @param replace Logical. Whether to replace existing assessments. Default is
 #'   FALSE.
@@ -122,6 +135,8 @@ val_pipeline <- function(
   # Note: "depends" this means --> c("Depends", "Imports", "LinkingTo")
   deps = c("depends", "suggests")[1], 
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   val_date = Sys.Date(),
   replace = FALSE, 
   out = Sys.getenv("RISK_OUTPATH", unset = getwd()),
@@ -169,6 +184,8 @@ val_pipeline <- function(
       metric_pkg      = metric_pkg,
       deps            = deps,
       deps_recursive  = deps_recursive,
+      rev_deps        = rev_deps,
+      rev_deps_recursive = rev_deps_recursive,
       val_date        = val_date,
       out             = out,
       opt_repos       = opt_repos,

--- a/R/val_prep_pipeline.R
+++ b/R/val_prep_pipeline.R
@@ -70,6 +70,8 @@ val_prep_pipeline <- function(
   metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   val_date = Sys.Date(),
   out = Sys.getenv("RISK_OUTPATH", unset = getwd()),
   opt_repos =
@@ -217,9 +219,11 @@ val_prep_pipeline <- function(
   # dep-frequency-sorted `pkgs` / `vers` / `avail_pkgs` triple lands
   # here as in val_build()'s no-prep path.
   tree       <- resolve_pkg_tree(
-    pkg_names      = build_pkgs,
-    deps           = deps,
-    deps_recursive = deps_recursive
+    pkg_names          = build_pkgs,
+    deps               = deps,
+    deps_recursive     = deps_recursive,
+    rev_deps           = rev_deps,
+    rev_deps_recursive = rev_deps_recursive
   )
   pkgs       <- tree$pkgs
   vers       <- tree$vers

--- a/man/resolve_pkg_tree.Rd
+++ b/man/resolve_pkg_tree.Rd
@@ -8,6 +8,8 @@ resolve_pkg_tree(
   pkg_names,
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   avail_pkgs = NULL
 )
 }
@@ -24,6 +26,22 @@ or \code{NULL}. Passed through to the \code{which} argument of
 
 \item{deps_recursive}{Logical. Whether dependency expansion is
 recursive. Passed straight through.}
+
+\item{rev_deps}{One of \code{"depends"}, \code{"suggests"},
+\code{c("depends","suggests")}, or \code{NULL} (default). When non-\code{NULL},
+the seed set is first expanded with its \strong{reverse} dependencies
+(via \code{tools::package_dependencies(reverse = TRUE, which = ...)})
+before forward-dep expansion runs. Use this when re-assessing a
+remediated package (e.g. \code{duckdb} flipped from High to Low) and
+you want everything that previously failed \emph{because} it depended
+on that pkg to be re-assessed too. \code{NULL} (default) preserves the
+pre-#105 behaviour of forward-only expansion.}
+
+\item{rev_deps_recursive}{Logical, default \code{FALSE}. Whether
+reverse-dep expansion walks the whole transitive tree. Default is
+\code{FALSE} because rev-dep trees explode fast (a foundational pkg
+like \code{Rcpp} has thousands of transitive dependents); flip to
+\code{TRUE} deliberately.}
 
 \item{avail_pkgs}{Optional data frame from
 \code{as.data.frame(available.packages())}. When \code{NULL}, one is

--- a/man/val_build.Rd
+++ b/man/val_build.Rd
@@ -10,6 +10,8 @@ val_build(
   metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   val_date = Sys.Date(),
   out = "riskassessment",
   replace = FALSE,
@@ -42,6 +44,18 @@ assessed without their dependencies.}
 
 \item{deps_recursive}{Logical indicating whether to include dependencies
 recursively. Default is TRUE.}
+
+\item{rev_deps}{Character or NULL. Types of \strong{reverse} dependencies
+to fold into the seed set before forward-dep expansion runs.
+Same shorthand as \code{deps} (\code{"depends"}, \code{"suggests"}, or both).
+\code{NULL} (default) means no rev-dep expansion. Only consulted when
+\code{prep = NULL}; a supplied \code{prep} already carries a resolved
+package tree.}
+
+\item{rev_deps_recursive}{Logical. Whether reverse-dep expansion
+walks the transitive tree. Default is \code{FALSE} because rev-dep
+trees can explode (foundational pkgs like \code{Rcpp} have thousands
+of transitive dependents). Ignored when \code{rev_deps = NULL}.}
 
 \item{val_date}{Date object or character string representing the date of the
 validation build. Default is the current date (Sys.Date()).}

--- a/man/val_pipeline.Rd
+++ b/man/val_pipeline.Rd
@@ -9,6 +9,8 @@ val_pipeline(
   metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   val_date = Sys.Date(),
   replace = FALSE,
   out = Sys.getenv("RISK_OUTPATH", unset = getwd()),
@@ -35,6 +37,21 @@ are "source" or "remote".}
 
 \item{deps_recursive}{Logical. Whether to consider dependencies recursively.
 Default is TRUE.}
+
+\item{rev_deps}{Character or NULL. Types of \strong{reverse} dependencies
+to fold into the seed set before forward-dep expansion runs.
+Same shorthand as \code{deps} (\code{"depends"} = Depends/Imports/LinkingTo,
+\code{"suggests"} = Suggests, \code{c("depends","suggests")} = both). \code{NULL}
+(default) preserves the pre-#105 behaviour of no rev-dep
+expansion. Use this when re-assessing a remediated package (e.g.
+\code{duckdb} flipped from High to Low) so every pkg that previously
+failed \emph{because} it depended on that pkg is re-assessed too.}
+
+\item{rev_deps_recursive}{Logical. Whether reverse-dep expansion
+walks the whole transitive tree. Default is \code{FALSE} because
+rev-dep trees explode fast (a foundational pkg like \code{Rcpp} has
+thousands of transitive dependents); flip to \code{TRUE} deliberately.
+Ignored when \code{rev_deps = NULL}.}
 
 \item{val_date}{Date. The date for validation. Default is the current date.}
 

--- a/man/val_prep_pipeline.Rd
+++ b/man/val_prep_pipeline.Rd
@@ -9,6 +9,8 @@ val_prep_pipeline(
   metric_pkg = c("riskmetric", "val.meter", "risk.assessr"),
   deps = c("depends", "suggests")[1],
   deps_recursive = TRUE,
+  rev_deps = NULL,
+  rev_deps_recursive = FALSE,
   val_date = Sys.Date(),
   out = Sys.getenv("RISK_OUTPATH", unset = getwd()),
   opt_repos = c(CRAN = "https://packagemanager.posit.co/cran/latest", BioC =
@@ -33,6 +35,21 @@ are "source" or "remote".}
 
 \item{deps_recursive}{Logical. Whether to consider dependencies recursively.
 Default is TRUE.}
+
+\item{rev_deps}{Character or NULL. Types of \strong{reverse} dependencies
+to fold into the seed set before forward-dep expansion runs.
+Same shorthand as \code{deps} (\code{"depends"} = Depends/Imports/LinkingTo,
+\code{"suggests"} = Suggests, \code{c("depends","suggests")} = both). \code{NULL}
+(default) preserves the pre-#105 behaviour of no rev-dep
+expansion. Use this when re-assessing a remediated package (e.g.
+\code{duckdb} flipped from High to Low) so every pkg that previously
+failed \emph{because} it depended on that pkg is re-assessed too.}
+
+\item{rev_deps_recursive}{Logical. Whether reverse-dep expansion
+walks the whole transitive tree. Default is \code{FALSE} because
+rev-dep trees explode fast (a foundational pkg like \code{Rcpp} has
+thousands of transitive dependents); flip to \code{TRUE} deliberately.
+Ignored when \code{rev_deps = NULL}.}
 
 \item{val_date}{Date. The date for validation. Default is the current date.}
 

--- a/tests/testthat/test-resolve_pkg_tree.R
+++ b/tests/testthat/test-resolve_pkg_tree.R
@@ -87,3 +87,98 @@ test_that("resolve_pkg_tree(): invalid `deps` value is caught with the stopcheck
     "which_deps"
   )
 })
+
+
+test_that("resolve_pkg_tree(): rev_deps=NULL (default) skips reverse expansion", {
+  ap <- local_avail()
+  called <- FALSE
+  res <- with_mocked_bindings(
+    package_dependencies = function(packages, which, recursive, reverse = FALSE) {
+      if (isTRUE(reverse)) called <<- TRUE
+      setNames(rep(list(character()), length(packages)), packages)
+    },
+    .package = "tools",
+    {
+      resolve_pkg_tree(
+        pkg_names      = c("A"),
+        deps           = "depends",
+        deps_recursive = TRUE,
+        avail_pkgs     = ap
+      )
+    }
+  )
+  expect_false(called)
+  expect_true("A" %in% res$pkgs)
+})
+
+
+test_that("resolve_pkg_tree(): rev_deps folds reverse-dep pkgs into the seed set", {
+  ap <- local_avail()
+  # Reverse-dep tree: rev(A) = {C, D}. Forward-dep tree of {A,C,D}: no deps.
+  fake_rev  <- list(A = c("C", "D"))
+  fake_fwd  <- list(A = character(), C = character(), D = character())
+
+  res <- with_mocked_bindings(
+    package_dependencies = function(packages, which, recursive, reverse = FALSE) {
+      if (isTRUE(reverse)) fake_rev else fake_fwd
+    },
+    .package = "tools",
+    {
+      resolve_pkg_tree(
+        pkg_names          = "A",
+        deps               = "depends",
+        deps_recursive     = TRUE,
+        rev_deps           = "depends",
+        rev_deps_recursive = FALSE,
+        avail_pkgs         = ap
+      )
+    }
+  )
+  expect_setequal(res$pkgs, c("A", "C", "D"))
+})
+
+
+test_that("resolve_pkg_tree(): rev_deps_recursive is forwarded to package_dependencies", {
+  ap <- local_avail()
+  seen_recursive <- NA
+  with_mocked_bindings(
+    package_dependencies = function(packages, which, recursive, reverse = FALSE) {
+      if (isTRUE(reverse)) seen_recursive <<- recursive
+      setNames(rep(list(character()), length(packages)), packages)
+    },
+    .package = "tools",
+    {
+      resolve_pkg_tree(
+        pkg_names          = "A",
+        deps               = "depends",
+        rev_deps           = "depends",
+        rev_deps_recursive = TRUE,
+        avail_pkgs         = ap
+      )
+    }
+  )
+  expect_true(seen_recursive)
+})
+
+
+test_that("resolve_pkg_tree(): rev_deps ignored when pkg_names is NULL", {
+  ap <- local_avail()
+  rev_called <- FALSE
+  res <- with_mocked_bindings(
+    package_dependencies = function(packages, which, recursive, reverse = FALSE) {
+      if (isTRUE(reverse)) rev_called <<- TRUE
+      setNames(rep(list(character()), length(packages)), packages)
+    },
+    .package = "tools",
+    {
+      resolve_pkg_tree(
+        pkg_names  = NULL,
+        deps       = NULL,
+        rev_deps   = "depends",
+        avail_pkgs = ap
+      )
+    }
+  )
+  expect_false(rev_called)
+  expect_setequal(res$pkgs, ap$Package)
+})


### PR DESCRIPTION
Closes #105.

## What

Adds two new symmetric args to `resolve_pkg_tree()`, `val_prep_pipeline()`, `val_build()`, and `val_pipeline()`:

- `rev_deps = NULL` — one of `"depends"`, `"suggests"`, or both. Same shorthand as `deps`.
- `rev_deps_recursive = FALSE` — whether the rev-dep walk is transitive.

When `rev_deps` is non-NULL and `pkg_names` is supplied, `resolve_pkg_tree()` first expands the seed set with reverse dependencies via `tools::package_dependencies(reverse = TRUE, which = ...)`, then runs the existing forward-dep sweep on the combined set. The forward dep_freq sort still governs assessment order.

## Why

To support the workflow described in #105: re-run a single remediated package (e.g. `duckdb` after a fix flips it from High to Low) plus everything that previously failed *because* it depended on that package. Before this PR the only lever was forward deps, which pulls in the tree the pkg depends on, not the tree that depends on it.

## Example

```r
val_build(
  pkg_names          = "duckdb",
  replace            = TRUE,
  deps               = "depends",
  deps_recursive     = TRUE,
  rev_deps           = "depends",
  rev_deps_recursive = FALSE  # direct dependents only; flip to TRUE deliberately
)
```

## Defaults & compatibility

- `rev_deps = NULL` (default) preserves pre-#105 behaviour exactly — the reverse-dep branch is a no-op.
- `rev_deps_recursive = FALSE` is intentional. Rev-dep trees explode fast (`Rcpp` has thousands of transitive dependents); recursive expansion should be a deliberate opt-in.
- `pkg_names = NULL` (the legacy "assess everything on CRAN" path) short-circuits rev-dep expansion, since expanding the reverse deps of the whole universe is meaningless.

## Notes

- Val_pipeline() forwards the new args to val_prep_pipeline() only. It passes `prep = prep` to val_build() so val_build's own rev_deps arg is a no-op in that path (same pattern as existing `deps`/`deps_recursive`).
- The `"depends"/"suggests"` → `tools::package_dependencies` which-enum translation is now factored into a shared local helper so forward + reverse use one source of truth.

## Tests

- 4 new `resolve_pkg_tree()` tests: default-NULL is a no-op; rev_deps folds pkgs into the seed set; rev_deps_recursive is forwarded correctly; pkg_names=NULL suppresses rev-dep expansion.
- Full suite: FAIL 2 | WARN 53 | SKIP 1 | PASS 758 — the 2 fails are the pre-existing `test-bioc-remote-initial-metrics` ones, unrelated.

## Docs / version

- Roxygen updated; `devtools::document()` regenerated `.Rd`s.
- `DESCRIPTION` bumped 0.1.21 → 0.1.22.
- `NEWS.md` entry under new `# val.pipeline 0.1.22` heading.