### PR TITLE
Populate decision_reason_note with direct DESCRIPTION deps (#107)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.21
+Version: 0.1.21.9001
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# val.pipeline (development version)
+
+- Fixed `decision_reason_note` listing the recursive Suggests closure
+  intersected with all failed packages (~100 unrelated transitive pkgs)
+  instead of the actual DESCRIPTION-level dep(s) that triggered the
+  downgrade. `val_pkg()` and `val_build()`'s dep-skip branch now capture
+  direct (non-recursive) `depends_direct` / `suggests_direct` alongside
+  the existing recursive fields; both the dep-skip branch and
+  `reject_iteration()` populate the note from the direct set. Legacy
+  meta bundles without the new fields fall back to the recursive fields.
+  (#107)
+
 # val.pipeline 0.1.21
 
 - Extracted the collation + wrap-up tail of `val_build()` into a new

--- a/R/global.R
+++ b/R/global.R
@@ -5,7 +5,7 @@ utils::globalVariables(c(
   "condition",
   "decision", "decision_reason", "decision_reason_note", "dep_failed",
   "dep_failed_matches", "sug_failed_matches",
-  "dep_freq", "depends", "deps",
+  "dep_freq", "depends", "depends_direct", "deps",
   "derived_col", "downloads_1yr", "ends_with", "exception_risk_category",
   "final_decision", "final_decision_reason_note", "final_risk",
   "final_risk_cat", "final_risk_catid",
@@ -13,7 +13,7 @@ utils::globalVariables(c(
   "met_dec_id", "metric", "metric_type", "news_curr", "news_current",
   "package", "pretty",
   "primary_risk_category", "repo_name", "reverse_dependencies",
-  "sug_failed", "suggests",
+  "sug_failed", "suggests", "suggests_direct",
   "dec_id_df", "decisions", "secondary_risk_category", "rule_lst",
   "Metric", "Type",
   "phase", "seconds", "total_s", "ver"

--- a/R/utils.R
+++ b/R/utils.R
@@ -1510,8 +1510,12 @@ split_join_cats <- function(
 #'
 #' @return `pkg_dat` with `final_decision`, `final_decision_reason`, and
 #'   `final_decision_reason_note` populated for every row. For dependency-
-#'   driven downgrades the note lists the failing dep pkg name(s), comma-
-#'   separated (see [identify_failed_deps()] and issue #37).
+#'   driven downgrades the note lists the failing **direct** dep pkg
+#'   name(s) (from `depends_direct` / `suggests_direct` if present in
+#'   `pkg_dat`, else falling back to `depends` / `suggests`), comma-
+#'   separated. To keep transitive-chain rows meaningful the failed set is
+#'   augmented with pkgs downgraded within this call before notes are
+#'   computed (see [identify_failed_deps()] and issues #37, #107).
 #'
 #' @importFrom dplyr mutate case_when select
 #' @importFrom purrr map_chr
@@ -1523,12 +1527,34 @@ reject_iteration <- function(pkg_dat, dec_reject, deps, decisions,
     failed_pkgs <- pkg_dat$pkg[pkg_dat$final_decision != decisions[1]]
   }
 
+  # Backwards compat: legacy pkg_dat frames (pre-#107) lack direct-dep
+  # list-cols. Fall back to the recursive fields so callers built
+  # against the older shape (and existing tests) keep working.
+  if (!"depends_direct" %in% names(pkg_dat))  pkg_dat$depends_direct  <- pkg_dat$depends
+  if (!"suggests_direct" %in% names(pkg_dat)) pkg_dat$suggests_direct <- pkg_dat$suggests
+
+  # First pass: which rows are downgrade candidates? Uses the RECURSIVE
+  # depends/suggests list-cols so a transitive failure still trips the
+  # downgrade in a single call (matches pre-#107 propagation semantics).
+  pkg_dat <- pkg_dat |>
+    dplyr::mutate(
+      dep_failed = purrr::map_lgl(depends,  function(x) any(x %in% failed_pkgs)),
+      sug_failed = purrr::map_lgl(suggests, function(x) any(x %in% failed_pkgs))
+    )
+
+  # Augment the failed set with pkgs about to be downgraded in this
+  # call. Ensures that when Z's direct dep Y (not yet in `failed_pkgs`)
+  # gets downgraded because Y's own recursive dep X failed, Z's note
+  # can still name Y as the direct-dep culprit instead of collapsing
+  # to NA.
+  in_scope_sug <- pkg_dat$sug_failed & ("Suggests" %in% deps)
+  new_failed   <- pkg_dat$pkg[pkg_dat$dep_failed | in_scope_sug]
+  aug_failed   <- unique(c(failed_pkgs, new_failed))
+
   pkg_dat |>
     dplyr::mutate(
-      dep_failed_matches = purrr::map_chr(depends,  identify_failed_deps, failed_pkgs = failed_pkgs),
-      sug_failed_matches = purrr::map_chr(suggests, identify_failed_deps, failed_pkgs = failed_pkgs),
-      dep_failed = !is.na(dep_failed_matches),
-      sug_failed = !is.na(sug_failed_matches)
+      dep_failed_matches = purrr::map_chr(depends_direct,  identify_failed_deps, failed_pkgs = aug_failed),
+      sug_failed_matches = purrr::map_chr(suggests_direct, identify_failed_deps, failed_pkgs = aug_failed)
     ) |>
     dplyr::mutate(
       final_decision = dplyr::case_when(
@@ -1544,9 +1570,10 @@ reject_iteration <- function(pkg_dat, dec_reject, deps, decisions,
         .default = decision_reason
       ),
       # When a pkg is downgraded because a dep (or suggest, if deps includes
-      # "Suggests") failed, list the failing dep pkg name(s) in the note.
-      # Best-effort -- may under-report if a chain of failures wasn't fully
-      # captured in `failed_pkgs` at this iteration (see issue #37).
+      # "Suggests") failed, list the failing DIRECT dep pkg name(s) in the
+      # note (see #107 for why direct-only). Best-effort -- may under-report
+      # if a chain of failures wasn't fully captured in `aug_failed` at this
+      # iteration (see issue #37).
       final_decision_reason_note = dplyr::case_when(
         decision_reason == "Pre-Approved package" ~ decision_reason_note,
         dep_failed ~ dep_failed_matches,

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -403,13 +403,38 @@ val_build <- function(
         ) |>
         unlist(use.names = FALSE)
 
+      # Direct (non-recursive) deps for `decision_reason_note`. See #107.
+      depends_direct <-
+        tools::package_dependencies(
+          packages = pkg,
+          db = available.packages(),
+          which = c("Depends", "Imports", "LinkingTo"),
+          recursive = FALSE
+        ) |>
+        unlist(use.names = FALSE)
+
+      suggests_direct <-
+        tools::package_dependencies(
+          packages = pkg,
+          db = available.packages(),
+          which = "Suggests",
+          recursive = FALSE
+        ) |>
+        unlist(use.names = FALSE)
+
       repo_src <- avail_pkgs |>
         dplyr::filter(Package %in% pkg) |>
         dplyr::pull(Repository) |>
         dirname() |> dirname()
       repo_name <- get_repo_origin(repo_src = repo_src, pkg_name = pkg)
 
-      dep_note <- identify_failed_deps(c(depends, suggests), failed_snapshot)
+      # Name the direct DESCRIPTION-level dep(s) that failed, not the
+      # recursive Suggests closure (which would list hundreds of
+      # transitive pkgs). See #107.
+      dep_note <- identify_failed_deps(
+        c(depends_direct, suggests_direct),
+        failed_snapshot
+      )
 
       pkg_meta <- list(
         pkg = pkg,
@@ -428,6 +453,8 @@ val_build <- function(
         final_decision_reason_note = dep_note,
         depends = if(identical(depends, character(0))) NA_character_ else depends,
         suggests = if(identical(suggests, character(0))) NA_character_ else suggests,
+        depends_direct  = if(identical(depends_direct,  character(0))) NA_character_ else depends_direct,
+        suggests_direct = if(identical(suggests_direct, character(0))) NA_character_ else suggests_direct,
         rev_deps = NA_character_,
         assessment_runtime = list(txt = NA_character_, mins = NA)
       )

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -430,11 +430,15 @@ val_build <- function(
 
       # Name the direct DESCRIPTION-level dep(s) that failed, not the
       # recursive Suggests closure (which would list hundreds of
-      # transitive pkgs). See #107.
-      dep_note <- identify_failed_deps(
-        c(depends_direct, suggests_direct),
-        failed_snapshot
-      )
+      # transitive pkgs). Scope by `deps` so failing suggests are only
+      # named when the caller propagates them (matches the same
+      # `"Suggests" %in% deps` gate used in reject_iteration()). See #107.
+      note_deps <- if ("Suggests" %in% deps) {
+        c(depends_direct, suggests_direct)
+      } else {
+        depends_direct
+      }
+      dep_note <- identify_failed_deps(note_deps, failed_snapshot)
 
       pkg_meta <- list(
         pkg = pkg,

--- a/R/val_finalize.R
+++ b/R/val_finalize.R
@@ -273,6 +273,13 @@ val_finalize <- function(
     x <- purrr::list_flatten(bundle)
     x$depends  <- list(x$depends)
     x$suggests <- list(x$suggests)
+    # Backwards-compat with legacy meta bundles (pre-#107): direct-dep
+    # fields may be absent -- fall back to the recursive fields so
+    # reject_iteration() still has something to intersect with.
+    if (is.null(x$depends_direct))  x$depends_direct  <- x$depends[[1]]
+    if (is.null(x$suggests_direct)) x$suggests_direct <- x$suggests[[1]]
+    x$depends_direct  <- list(x$depends_direct)
+    x$suggests_direct <- list(x$suggests_direct)
     x$rev_deps <- list(x$rev_deps)
     x$sys_info <- list(x$sys_info)
     pkgs_df0_rows[[i]] <- dplyr::as_tibble(x)

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -159,8 +159,31 @@ val_pkg <- function(
       recursive = TRUE # this really blows up for almost any pkg
     ) |>
     unlist(use.names = FALSE) 
-  
-  
+
+  # Direct (non-recursive) deps: what's declared in this package's own
+  # DESCRIPTION. Used to populate `decision_reason_note` so a
+  # dep-driven downgrade names a real DESCRIPTION-level dep instead of
+  # a transitive package pulled from the recursive Suggests closure
+  # (which for most packages is 1000-2000 pkgs long). See #107.
+  depends_direct <-
+    tools::package_dependencies(
+      packages = pkg,
+      db = avail_pkgs |> as.matrix(),
+      which = c("Depends", "Imports", "LinkingTo"),
+      recursive = FALSE
+    ) |>
+    unlist(use.names = FALSE)
+
+  suggests_direct <-
+    tools::package_dependencies(
+      packages = pkg,
+      db = avail_pkgs |> as.matrix(),
+      which = "Suggests",
+      recursive = FALSE
+    ) |>
+    unlist(use.names = FALSE)
+
+
   #
   # ---- Assess ---- 
   #
@@ -721,6 +744,8 @@ val_pkg <- function(
     final_decision_reason_note = NA_character_, # Will be set later
     depends = if(identical(depends, character(0))) NA_character_ else depends,
     suggests = if(identical(suggests, character(0))) NA_character_ else suggests,
+    depends_direct  = if(identical(depends_direct,  character(0))) NA_character_ else depends_direct,
+    suggests_direct = if(identical(suggests_direct, character(0))) NA_character_ else suggests_direct,
     rev_deps = if(is.null(pkg_assessment$reverse_dependencies)) NA_character_ else pkg_assessment$reverse_dependencies |> as.vector(),
     assessment_runtime = list(txt = ass_mins_txt, mins = ass_mins),
     # Per-phase elapsed seconds captured via val_time_block() around

--- a/man/reject_iteration.Rd
+++ b/man/reject_iteration.Rd
@@ -27,8 +27,12 @@ on this iteration. If \code{NULL}, derived from \code{pkg_dat$final_decision != 
 \value{
 \code{pkg_dat} with \code{final_decision}, \code{final_decision_reason}, and
 \code{final_decision_reason_note} populated for every row. For dependency-
-driven downgrades the note lists the failing dep pkg name(s), comma-
-separated (see \code{\link[=identify_failed_deps]{identify_failed_deps()}} and issue #37).
+driven downgrades the note lists the failing \strong{direct} dep pkg
+name(s) (from \code{depends_direct} / \code{suggests_direct} if present in
+\code{pkg_dat}, else falling back to \code{depends} / \code{suggests}), comma-
+separated. To keep transitive-chain rows meaningful the failed set is
+augmented with pkgs downgraded within this call before notes are
+computed (see \code{\link[=identify_failed_deps]{identify_failed_deps()}} and issues #37, #107).
 }
 \description{
 Given a data.frame of per-package risk assessments (one row per package,

--- a/tests/testthat/test-reject_iteration.R
+++ b/tests/testthat/test-reject_iteration.R
@@ -118,7 +118,80 @@ test_that("reject_iteration() derives failed_pkgs from final_decision if NA", {
   expect_equal(out$final_decision_reason[out$pkg == "C"], "Dependency")
 })
 
-# ---- Fixed-point convergence loop (regression, #103) ----------------------
+test_that("reject_iteration() note names DIRECT deps, not recursive closure (#107)", {
+  # Chain: A (High, seed) <- B (depends A directly) <- C (depends B directly).
+  # Recursive-depends of C includes both A and B; direct-depends of C is
+  # only B. Pre-#107, C's note would have listed "A, B" (recursive closure
+  # intersected with failed). Post-#107, C's note names only "B" -- its
+  # actual DESCRIPTION-level dep.
+  pkg_dat <- tibble::tibble(
+    pkg              = c("A", "B", "C"),
+    decision         = c("High", "Low", "Low"),
+    decision_reason  = rep("Risk Assessment", 3),
+    final_decision         = NA_character_,
+    final_decision_reason  = NA_character_,
+    decision_reason_note   = NA_character_,
+    final_decision_reason_note = NA_character_,
+    depends         = list(character(0), "A",           c("A", "B")),
+    suggests        = list(character(0), character(0),  character(0)),
+    depends_direct  = list(character(0), "A",           "B"),
+    suggests_direct = list(character(0), character(0),  character(0))
+  )
+  out <- reject_iteration(pkg_dat, dec_reject = "High",
+                          deps = "depends", decisions = decisions,
+                          failed_pkgs = "A")
+  expect_equal(out$final_decision, c("High", "High", "High"))
+  expect_equal(out$final_decision_reason_note[out$pkg == "B"], "A")
+  # C's note must be "B" (its direct dep), not "A, B" (recursive closure).
+  expect_equal(out$final_decision_reason_note[out$pkg == "C"], "B")
+})
+
+test_that("reject_iteration() falls back to recursive deps when direct cols absent", {
+  # Legacy pkg_dat (pre-#107) has no depends_direct / suggests_direct
+  # list-cols. reject_iteration() must still work and populate the note
+  # by falling back to the recursive `depends` / `suggests` list-cols.
+  pkg_dat <- make_pkg_dat()
+  expect_false("depends_direct" %in% names(pkg_dat))
+  failed  <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]
+  out <- reject_iteration(pkg_dat, dec_reject = "High",
+                          deps = "depends", decisions = decisions,
+                          failed_pkgs = failed)
+  expect_equal(out$final_decision[out$pkg == "C"], "High")
+  expect_equal(out$final_decision_reason_note[out$pkg == "C"], "B")
+})
+
+test_that("reject_iteration() note does NOT include recursive-Suggests noise (#107)", {
+  # Regression: pak/lintr were pre-approved and dep-skipped; their
+  # decision_reason_note was populated with intersect(recursive Suggests
+  # closure, failed_pkgs) yielding ~100 unrelated transitive pkg names.
+  # In the reject_iteration path the same bug leaked into propagated
+  # notes. Guard against reintroduction: given a pkg whose recursive
+  # Suggests closure includes many failed pkgs but whose direct
+  # deps/suggests do NOT, the note stays NA (pkg isn't downgraded).
+  pkg_dat <- tibble::tibble(
+    pkg              = c("X", "Y", "Z"),
+    decision         = c("High", "High", "Low"),
+    decision_reason  = rep("Risk Assessment", 3),
+    final_decision         = NA_character_,
+    final_decision_reason  = NA_character_,
+    decision_reason_note   = NA_character_,
+    final_decision_reason_note = NA_character_,
+    # Z's RECURSIVE suggests includes both failed pkgs (X, Y), but its
+    # DIRECT deps / suggests are empty -- so Z should NOT be downgraded
+    # under deps = "depends" and its note should remain NA.
+    depends         = list(character(0), character(0), character(0)),
+    suggests        = list(character(0), character(0), c("X", "Y")),
+    depends_direct  = list(character(0), character(0), character(0)),
+    suggests_direct = list(character(0), character(0), character(0))
+  )
+  out <- reject_iteration(pkg_dat, dec_reject = "High",
+                          deps = "depends", decisions = decisions,
+                          failed_pkgs = c("X", "Y"))
+  expect_equal(out$final_decision[out$pkg == "Z"], "Low")
+  expect_true(is.na(out$final_decision_reason_note[out$pkg == "Z"]))
+})
+
+
 
 # Guards val_build()'s (and val_finalize()'s in #101) reject_iteration()
 # convergence loop against an infinite-loop bug introduced by a stray


### PR DESCRIPTION
Closes #107.

## Problem

Pre-approved packages `pak` and `lintr` were rejected with `decision_reason = "Dependency"`, and their `decision_reason_note` was populated with the same ~100-package list (BiasedUrn, BiocVersion, Cairo, ..., yyjsonr) — none of which appear in their DESCRIPTIONs.

Root cause: two spots concat'd `c(depends, suggests)` and intersected with `failed_pkgs` for the note, but `depends` / `suggests` in meta bundles are computed with `recursive = TRUE`. For most packages the recursive Suggests closure is 1000-2000 pkgs, so the intersection surfaces every failed transitive Suggest.

Scope check on the `R_4.5.2/20260730` run:

| Note length | # pkgs affected |
|---|---|
| >200 chars | 139 |
| >500 chars | 32  |

The affected pkgs include big names like `Seurat`, `FactoMineR`, `rstanarm`, `clusterProfiler`, plus every dep-skipped pre-approved.

## Fix

- `val_pkg()` and `val_build()`'s pre-skip branch capture `depends_direct` / `suggests_direct` (non-recursive) alongside the existing recursive fields.
- The pre-skip branch builds `dep_note` from `c(depends_direct, suggests_direct)` intersected with `failed_snapshot`.
- `val_finalize()` collation list-cols the two new fields, with a fallback to `depends` / `suggests` for legacy meta bundles.
- `reject_iteration()` populates the note from `depends_direct` / `suggests_direct` (with the same fallback). Downgrade *trigger* still uses the recursive fields, preserving pre-#107 propagation semantics — `reject_iteration()` still converges in the same number of outer-loop iterations. To keep transitive-chain rows meaningful, the failed set is augmented within a single call with pkgs about to be downgraded, so a row like `Z (depends: Y)` where `Y (depends: X)` was just downgraded gets note = `"Y"` instead of NA.

## Tests

`devtools::test()`: 760 pass, 2 fail (pre-existing, unrelated — `test-bioc-remote-initial-metrics.R`, fails on `main` too), 1 skip.

Added three new tests in `test-reject_iteration.R`:

1. Direct-dep chain: given `A (High) <- B (direct A) <- C (direct B)`, C's note is `"B"`, not `"A, B"`.
2. Backwards-compat: legacy `pkg_dat` frames without `depends_direct` fall back to `depends`.
3. Regression guard: a row whose only overlap with `failed_pkgs` is via its *recursive* Suggests closure is NOT downgraded and its note stays NA (the exact pattern that produced the pak/lintr bug).

## Before / after (illustrative — pak & lintr from `R_4.5.2/20260720`)

| pkg   | note len before | note (before, truncated)                                                            |
|-------|----------------:|-------------------------------------------------------------------------------------|
| pak   | 771 chars       | AnnotationFilter, AnnotationForge, Bessel, BiasedUrn, BiocVersion, Cairo, ...       |
| lintr | 716 chars       | AnnotationFilter, AnnotationForge, Bessel, BiasedUrn, BiocVersion, Cairo, ...       |

After: pak's note would list only pkgs that appear in pak's DESCRIPTION (Depends/Imports/LinkingTo/Suggests direct) AND are in `failed_pkgs` — a much shorter, actionable list. Same for lintr.

## Follow-ups (not in this PR)

- **Pre-approved packages getting dep-skipped.** `pak` and `lintr` are on the config `approved_pkgs` list, but the `val_build()` pre-skip branch doesn't check that — it just downgrades based on `dont_run`. `reject_iteration()` has a "never downgrade Pre-Approved" carve-out but it's keyed off `decision_reason == "Pre-Approved package"`, which pre-skipped rows don't carry. Worth filing separately.