### PR TITLE
Narrow Pre-Approved carve-out: downgrade when a dep failed (#110)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.22
+Version: 0.1.22.9001
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,18 @@
 # val.pipeline (development version)
 
-- Retired the `ac-dev` local-superset branch workflow from
-  `.github/copilot-instructions.md`. Agent-directed PRs now cut from
-  `main`, PR to `main`, and stop there; no local ac-dev merge step.
+- Narrowed `reject_iteration()`'s Pre-Approved carve-out so a package on
+  the config `approved_pkgs` list is protected from dep-driven downgrade
+  only when none of its runtime deps actually failed. When a Pre-Approved
+  pkg's dep DID fail (PPM can no longer serve it because its install
+  closure is broken) the pkg is downgraded to the reject category with
+  `final_decision_reason = "Pre-Approved (dep failed)"` so an operator
+  can distinguish it from an ordinary dep-driven downgrade and either
+  fix the upstream dep or drop the pkg from `approved_pkgs`.
+  `val_build()`'s pre-skip branch was updated to emit the same reason
+  string when the pre-skipped pkg is on `approved_pkgs`, and
+  `val_pipeline_report()`'s summary gained a small section listing every
+  Pre-Approved-with-failed-dep pkg + the failing direct dep(s), so the
+  actionable list surfaces at the top of the report. (#110)
 - Fixed `decision_reason_note` listing the recursive Suggests closure
   intersected with all failed packages (~100 unrelated transitive pkgs)
   instead of the actual DESCRIPTION-level dep(s) that triggered the

--- a/R/global.R
+++ b/R/global.R
@@ -5,6 +5,7 @@ utils::globalVariables(c(
   "condition",
   "decision", "decision_reason", "decision_reason_note", "dep_failed",
   "dep_failed_matches", "sug_failed_matches",
+  "is_preapproved", "sug_in_scope", "preapp_dep_bad", "preapp_dep_ok",
   "dep_freq", "depends", "depends_direct", "deps",
   "derived_col", "downloads_1yr", "ends_with", "exception_risk_category",
   "final_decision", "final_decision_reason_note", "final_risk",

--- a/R/utils.R
+++ b/R/utils.R
@@ -1486,9 +1486,13 @@ split_join_cats <- function(
 #' compute the `final_decision` and `final_decision_reason` for every row by
 #' marking any package whose dependencies (or Suggests, when `"Suggests"` is
 #' in `deps`) appear in `failed_pkgs` as `dec_reject`. Pre-approved packages
-#' are never downgraded. Packages with no failing dep carry their original
-#' `decision` / `decision_reason` through to `final_decision` /
-#' `final_decision_reason`.
+#' whose deps are all clean carry their original decision through untouched;
+#' pre-approved packages whose deps DID fail are downgraded to `dec_reject`
+#' with `final_decision_reason = "Pre-Approved (dep failed)"` so an operator
+#' can distinguish them from ordinary dep-driven downgrades (they can't be
+#' served by PPM because their install closure is broken; see #110).
+#' Packages with no failing dep carry their original `decision` /
+#' `decision_reason` through to `final_decision` / `final_decision_reason`.
 #'
 #' The function is designed to be called iteratively from `val_build()` until
 #' the set of failing packages stabilizes (a package can become "failed"
@@ -1557,16 +1561,29 @@ reject_iteration <- function(pkg_dat, dec_reject, deps, decisions,
       sug_failed_matches = purrr::map_chr(suggests_direct, identify_failed_deps, failed_pkgs = aug_failed)
     ) |>
     dplyr::mutate(
+      # A pre-approved pkg whose runtime dep failed CAN'T be served by
+      # PPM (the install closure is broken), so downgrade it like any
+      # other dep-failed pkg but flag the reason as
+      # `"Pre-Approved (dep failed)"` so an operator can either fix
+      # the upstream dep or drop the pkg from `approved_pkgs`.
+      # Pre-approved pkgs with all deps clean are still protected.
+      # See #110.
+      is_preapproved  = decision_reason == "Pre-Approved package",
+      sug_in_scope    = sug_failed & ("Suggests" %in% deps),
+      preapp_dep_bad  = is_preapproved & (dep_failed | sug_in_scope),
+      preapp_dep_ok   = is_preapproved & !dep_failed & !sug_in_scope,
       final_decision = dplyr::case_when(
-        decision_reason == "Pre-Approved package" ~ decision,
-        dep_failed ~ dec_reject,
-        sug_failed & ("Suggests" %in% deps) ~ dec_reject,
+        preapp_dep_ok  ~ decision,
+        preapp_dep_bad ~ dec_reject,
+        dep_failed     ~ dec_reject,
+        sug_in_scope   ~ dec_reject,
         .default = decision
       ),
       final_decision_reason = dplyr::case_when(
-        decision_reason == "Pre-Approved package" ~ decision_reason,
-        dep_failed ~ "Dependency",
-        sug_failed & ("Suggests" %in% deps) ~ "Dependency",
+        preapp_dep_ok  ~ decision_reason,
+        preapp_dep_bad ~ "Pre-Approved (dep failed)",
+        dep_failed     ~ "Dependency",
+        sug_in_scope   ~ "Dependency",
         .default = decision_reason
       ),
       # When a pkg is downgraded because a dep (or suggest, if deps includes
@@ -1575,13 +1592,16 @@ reject_iteration <- function(pkg_dat, dec_reject, deps, decisions,
       # if a chain of failures wasn't fully captured in `aug_failed` at this
       # iteration (see issue #37).
       final_decision_reason_note = dplyr::case_when(
-        decision_reason == "Pre-Approved package" ~ decision_reason_note,
-        dep_failed ~ dep_failed_matches,
-        sug_failed & ("Suggests" %in% deps) ~ sug_failed_matches,
+        preapp_dep_ok  ~ decision_reason_note,
+        preapp_dep_bad & dep_failed ~ dep_failed_matches,
+        preapp_dep_bad & sug_in_scope ~ sug_failed_matches,
+        dep_failed     ~ dep_failed_matches,
+        sug_in_scope   ~ sug_failed_matches,
         .default = decision_reason_note
       )
     ) |>
-    dplyr::select(-dep_failed, -sug_failed, -dep_failed_matches, -sug_failed_matches)
+    dplyr::select(-dep_failed, -sug_failed, -dep_failed_matches, -sug_failed_matches,
+                  -is_preapproved, -sug_in_scope, -preapp_dep_bad, -preapp_dep_ok)
 }
 
 

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -440,6 +440,18 @@ val_build <- function(
       }
       dep_note <- identify_failed_deps(note_deps, failed_snapshot)
 
+      # If the pkg is on the config `approved_pkgs` list, distinguish it
+      # from an ordinary dep-driven downgrade so an operator can chase
+      # the upstream dep (or drop the pkg from `approved_pkgs`). Keeps
+      # this pre-skip branch consistent with reject_iteration()'s
+      # narrowed Pre-Approved carve-out (#110).
+      approved_pkgs <- pull_config(val = "approved_pkgs", rule_type = "default")
+      dep_reason <- if (pkg %in% approved_pkgs) {
+        "Pre-Approved (dep failed)"
+      } else {
+        "Dependency"
+      }
+
       pkg_meta <- list(
         pkg = pkg,
         ver = ver,
@@ -450,10 +462,10 @@ val_build <- function(
         ref = NA_character_,
         metric_pkg = NA_character_,
         decision = decisions[length(decisions)],
-        decision_reason = "Dependency",
+        decision_reason = dep_reason,
         decision_reason_note = dep_note,
         final_decision = decisions[length(decisions)],
-        final_decision_reason = "Dependency",
+        final_decision_reason = dep_reason,
         final_decision_reason_note = dep_note,
         depends = if(identical(depends, character(0))) NA_character_ else depends,
         suggests = if(identical(suggests, character(0))) NA_character_ else suggests,

--- a/R/val_finalize.R
+++ b/R/val_finalize.R
@@ -380,15 +380,18 @@ val_finalize <- function(
 
   purrr::pwalk(
     list(changed_pkgs$pkg, changed_pkgs$ver,
+         changed_pkgs$final_decision_reason,
          changed_pkgs$final_decision_reason_note),
-    function(pkg, ver, note){
+    function(pkg, ver, reason, note){
       pkg_v <- paste(pkg, ver, sep = "_")
       pkg_meta_file <- file.path(assessed, glue::glue("{pkg_v}_meta.rds"))
       pkg_meta_file <- pkg_meta_file[file.exists(pkg_meta_file)]
       if (length(pkg_meta_file) > 0) {
         purrr::walk(pkg_meta_file, function(f){
           dep_meta <- readRDS(f)
-          dep_meta$final_decision_reason <- "Dependency"
+          # `reason` may be "Dependency" or "Pre-Approved (dep failed)"
+          # (#110), whichever reject_iteration() emitted.
+          dep_meta$final_decision_reason <- reason
           dep_meta$final_decision_reason_note <- note
           dep_meta$final_decision <- decisions[length(decisions)]
           saveRDS(dep_meta, f)

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -395,6 +395,36 @@ reason_counts <- qual_metadata |>
 itable(reason_counts, default_page_size = 10)
 ```
 
+## Pre-Approved packages that failed dependency propagation
+
+Packages on the config `approved_pkgs` list that had to be downgraded
+because at least one runtime dependency failed its assessment. PPM can't
+serve these packages until either the failing upstream dep is fixed or the
+package is removed from `approved_pkgs`. The note column names the direct
+DESCRIPTION-level dep(s) that failed. See #110.
+
+```{r preapproved-dep-failed}
+preapp_bad <- qual_metadata |>
+  dplyr::filter(final_decision_reason == "Pre-Approved (dep failed)") |>
+  dplyr::arrange(pkg) |>
+  dplyr::transmute(
+    Package = pkg,
+    Version = ver,
+    `Failing dep(s)` = ifelse(is.na(final_decision_reason_note) |
+                                final_decision_reason_note == "",
+                              "(unrecorded)", final_decision_reason_note)
+  )
+```
+
+**`r nrow(preapp_bad)`** Pre-Approved package(s) could not be qualified in
+this run.
+
+```{r preapproved-dep-failed-tbl}
+if (nrow(preapp_bad) > 0L) {
+  itable(preapp_bad, default_page_size = 25)
+}
+```
+
 # Packages by Risk Category
 
 The tables below list every package in each risk tier, with the reason and

--- a/man/reject_iteration.Rd
+++ b/man/reject_iteration.Rd
@@ -40,9 +40,13 @@ with \code{decision}, \code{decision_reason}, \code{depends}, \code{suggests} li
 compute the \code{final_decision} and \code{final_decision_reason} for every row by
 marking any package whose dependencies (or Suggests, when \code{"Suggests"} is
 in \code{deps}) appear in \code{failed_pkgs} as \code{dec_reject}. Pre-approved packages
-are never downgraded. Packages with no failing dep carry their original
-\code{decision} / \code{decision_reason} through to \code{final_decision} /
-\code{final_decision_reason}.
+whose deps are all clean carry their original decision through untouched;
+pre-approved packages whose deps DID fail are downgraded to \code{dec_reject}
+with \code{final_decision_reason = "Pre-Approved (dep failed)"} so an operator
+can distinguish them from ordinary dep-driven downgrades (they can't be
+served by PPM because their install closure is broken; see #110).
+Packages with no failing dep carry their original \code{decision} /
+\code{decision_reason} through to \code{final_decision} / \code{final_decision_reason}.
 }
 \details{
 The function is designed to be called iteratively from \code{val_build()} until

--- a/tests/testthat/test-reject_iteration.R
+++ b/tests/testthat/test-reject_iteration.R
@@ -90,15 +90,86 @@ test_that("reject_iteration() only downgrades on Suggests when deps has it", {
   expect_equal(out_sug$final_decision_reason_note[out_sug$pkg == "D"], "B")
 })
 
-test_that("reject_iteration() never downgrades Pre-Approved packages", {
+test_that("reject_iteration() protects Pre-Approved packages with no failing dep (#110)", {
+  # Chain: A (Low, seed), B (High, seed), C (Pre-Approved, no failing dep),
+  #        D (Pre-Approved, depends on failed B) -- see next test.
+  # C's only dep is A (Low). No dep failed => Pre-Approved carve-out fires
+  # and C stays Low / "Pre-Approved package".
   pkg_dat <- make_pkg_dat()
-  # Mark C (which depends on failed B) as Pre-Approved
   pkg_dat$decision_reason[pkg_dat$pkg == "C"] <- "Pre-Approved package"
+  # Rewrite C's deps so it does NOT depend on failing B (only on A).
+  pkg_dat$depends[[which(pkg_dat$pkg == "C")]] <- "A"
   failed <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]
   out <- reject_iteration(pkg_dat, dec_reject = "High",
                           deps = "depends", decisions = decisions,
                           failed_pkgs = failed)
-  # Even though C's dep failed, pre-approval protects it
+  expect_equal(out$final_decision[out$pkg == "C"], "Low")
+  expect_equal(
+    out$final_decision_reason[out$pkg == "C"],
+    "Pre-Approved package"
+  )
+})
+
+test_that("reject_iteration() downgrades Pre-Approved pkgs with failed deps (#110)", {
+  # Pre-Approved pkg C depends on failing B. Under #110's narrowed
+  # carve-out, C should be downgraded to High with reason
+  # "Pre-Approved (dep failed)" so an operator can distinguish it from
+  # an ordinary dep-driven downgrade. Note names the failing dep.
+  pkg_dat <- make_pkg_dat()
+  pkg_dat$decision_reason[pkg_dat$pkg == "C"] <- "Pre-Approved package"
+  failed <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]  # "B"
+  out <- reject_iteration(pkg_dat, dec_reject = "High",
+                          deps = "depends", decisions = decisions,
+                          failed_pkgs = failed)
+  expect_equal(out$final_decision[out$pkg == "C"], "High")
+  expect_equal(
+    out$final_decision_reason[out$pkg == "C"],
+    "Pre-Approved (dep failed)"
+  )
+  expect_equal(out$final_decision_reason_note[out$pkg == "C"], "B")
+})
+
+test_that("reject_iteration() downgrades Pre-Approved pkgs with failing Suggests (when in scope) (#110)", {
+  # Pre-Approved pkg D suggests failing B. When deps includes
+  # "Suggests", D should be downgraded to "Pre-Approved (dep failed)".
+  # When deps = "depends" only, D is protected.
+  pkg_dat <- make_pkg_dat()
+  pkg_dat$decision_reason[pkg_dat$pkg == "D"] <- "Pre-Approved package"
+  failed <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]  # "B"
+
+  out_dep <- reject_iteration(pkg_dat, dec_reject = "High",
+                              deps = "depends", decisions = decisions,
+                              failed_pkgs = failed)
+  expect_equal(out_dep$final_decision[out_dep$pkg == "D"], "Low")
+  expect_equal(
+    out_dep$final_decision_reason[out_dep$pkg == "D"],
+    "Pre-Approved package"
+  )
+
+  out_sug <- reject_iteration(pkg_dat, dec_reject = "High",
+                              deps = c("depends", "Suggests"),
+                              decisions = decisions, failed_pkgs = failed)
+  expect_equal(out_sug$final_decision[out_sug$pkg == "D"], "High")
+  expect_equal(
+    out_sug$final_decision_reason[out_sug$pkg == "D"],
+    "Pre-Approved (dep failed)"
+  )
+  expect_equal(out_sug$final_decision_reason_note[out_sug$pkg == "D"], "B")
+})
+
+test_that("reject_iteration() never downgrades Pre-Approved packages", {
+  # #110 narrowed this: Pre-Approved is protected only when NO dep
+  # failed. Since C's dep B is failing in `make_pkg_dat()`, we point C
+  # at a non-failing dep for this test so the carve-out fires.
+  pkg_dat <- make_pkg_dat()
+  # Mark C as Pre-Approved and rewire its dep to A (Low, not failing).
+  pkg_dat$decision_reason[pkg_dat$pkg == "C"] <- "Pre-Approved package"
+  pkg_dat$depends[[which(pkg_dat$pkg == "C")]] <- "A"
+  failed <- pkg_dat$pkg[pkg_dat$decision != decisions[1]]
+  out <- reject_iteration(pkg_dat, dec_reject = "High",
+                          deps = "depends", decisions = decisions,
+                          failed_pkgs = failed)
+  # No dep of C failed => pre-approval protects it
   expect_equal(out$final_decision[out$pkg == "C"], "Low")
   expect_equal(
     out$final_decision_reason[out$pkg == "C"],

--- a/tests/testthat/test-val_pipeline_report.R
+++ b/tests/testthat/test-val_pipeline_report.R
@@ -406,6 +406,28 @@ test_that("val_pipeline_report renders Pre-Filter Summary when RDS present", {
   expect_true(grepl("pf_pkg02", html, fixed = TRUE))
 })
 
+test_that("summary_template includes Pre-Approved (dep failed) section (#110)", {
+  # Source-level guard: the small operator-facing table that lists every
+  # pkg with final_decision_reason == "Pre-Approved (dep failed)" (see
+  # #110) should live in the summary template so an operator can see at a
+  # glance which pre-approved pkgs need upstream attention.
+  qmd <- system.file(
+    "report", "summary", "summary_template.qmd",
+    package = "val.pipeline"
+  )
+  if (!nzchar(qmd) || !file.exists(qmd)) {
+    qmd <- file.path("..", "..", "inst", "report", "summary",
+                     "summary_template.qmd")
+  }
+  skip_if_not(file.exists(qmd), "summary_template.qmd not found")
+  src <- paste(readLines(qmd, warn = FALSE), collapse = "\n")
+  expect_true(grepl("Pre-Approved packages that failed dependency propagation",
+                    src, fixed = TRUE))
+  expect_true(grepl("Pre-Approved \\(dep failed\\)", src))
+  # Table chunk is present and filters on the reason string.
+  expect_match(src, "preapp_bad\\s*<-")
+})
+
 test_that("summary_template gates dropped-packages table on HTML output", {
   # Source-level guard: the per-package dropped table is intentionally
   # omitted from PDF renders because a full CRAN-scale run can produce a


### PR DESCRIPTION
Closes #110. **Stacked on #108** — targets that branch as base; will retarget `main` once #108 merges.

## Problem

`reject_iteration()`'s existing Pre-Approved carve-out is unconditional:

```r
final_decision = dplyr::case_when(
  decision_reason == "Pre-Approved package" ~ decision,   # always fires
  dep_failed ~ dec_reject,
  ...
)
```

So a pkg on `approved_pkgs` was protected even when its runtime deps failed. That produced a `qual_metadata.rds` claiming `pak = Low / Pre-Approved package` while PPM physically could not install pak because its install closure was broken.

Meanwhile `val_build()`'s pre-skip branch didn't consult `approved_pkgs` at all, so the same pkg dep-skipped there ended up High/Dependency. The two paths disagreed.

## Fix

1. **`reject_iteration()`**: keep the Pre-Approved carve-out only when NO dep failed. When a Pre-Approved pkg's dep DID fail, downgrade to `dec_reject` with reason `"Pre-Approved (dep failed)"` so an operator can either chase the upstream dep or drop the pkg from `approved_pkgs`. Same `"Suggests" %in% deps` gating applies to the Suggests channel.
2. **`val_build()`'s pre-skip branch**: consult `approved_pkgs` via `pull_config()` and emit the same `"Pre-Approved (dep failed)"` reason. The two propagation paths now agree.
3. **`val_finalize()`'s per-meta rewrite step**: propagate whichever reason string `reject_iteration()` emitted (`"Dependency"` or `"Pre-Approved (dep failed)"`) instead of hardcoding `"Dependency"`.

## Before / after

| Pre-Approved pkg | dep status              | before                              | after                                          |
|-------------------|-------------------------|-------------------------------------|------------------------------------------------|
| all deps clean    | ✓                       | Low / `Pre-Approved package`     | Low / `Pre-Approved package` *(unchanged)*  |
| dep failed        | ✗                       | Low / `Pre-Approved package` *(lies)* | High / `Pre-Approved (dep failed)`        |

## Tests

Full suite: 770 pass (2 pre-existing failures in `test-bioc-remote-initial-metrics.R`, unrelated). New in `test-reject_iteration.R`:

- Pre-Approved with a failed direct Depends → downgraded to `"Pre-Approved (dep failed)"`, note names the dep.
- Pre-Approved with a failed direct Suggests → protected when `deps = "depends"`; downgraded when deps includes `"Suggests"`.
- The existing "never downgrades Pre-Approved" test now points C's dep at a non-failing pkg so the carve-out fires cleanly.

## Follow-ups (intentionally not in this PR)

- Small `val_pipeline_report()` summary section listing every `"Pre-Approved (dep failed)"` pkg + its failing direct dep(s) — happy to open once the reason-string label is settled (or fold it in here if you'd rather).