### PR TITLE
Widen pass_primary bypass to Low tier's floor (#112)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.22.9002
+Version: 0.1.23
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.22.9001
+Version: 0.1.22.9002
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,13 @@
   `reject_iteration()` populate the note from the direct set. Legacy
   meta bundles without the new fields fall back to the recursive fields.
   (#107)
+- Widened `rip_cats_by_pkg()`'s `pass_primary` bypass so a package on the
+  `pass_primary` allow-list is exempted from the `downloads_1yr` primary
+  metric when its downloads sit below the *Low* tier's floor (upper
+  `downloads_1yr` bound, e.g. 200k under the default config), not just
+  below the *High* tier's ceiling (lower bound, e.g. 80k). Packages in
+  the Medium tier would still land in Medium on `downloads_1yr` alone
+  and fail `accept_cats: Low`, defeating the point of the bypass. (#112)
 
 # val.pipeline 0.1.21
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1100,39 +1100,44 @@ rip_cats_by_pkg <- function(
   # These are typically lower download pkgs that derserve their day in court
   bypass_primary  <- pull_config(val = "pass_primary", rule_type = "default")
 
-  # Lowest boundary of the `downloads_1yr` primary rule, derived directly
-  # from dec_df so we stay in sync with whatever the config says (rather
-  # than hard-coding it here and drifting out of date). Combining
-  # to_the_limit(low = TRUE) and to_the_limit(low = FALSE) across every
-  # `downloads_1yr` row picks up boundaries expressed as `< X`, `> X`,
-  # `<= X`, `>= X`, and `dplyr::between(., a, b)` alike. Compound
-  # conditions like `is.na(.x) | .x < X` return NA from to_the_limit()
-  # and are silently ignored — as long as one of the other rows for the
-  # same metric names the boundary (e.g. Medium's `between(80000, ...)`
-  # or Low's `> 240000`), we'll pick up the 80k floor. If nothing is
-  # parseable, we fall back to Inf so the bypass behaves as it did
-  # before this guard was added (applies to any `pass_primary` member).
+  # Highest finite boundary of the `downloads_1yr` primary rule, derived
+  # directly from dec_df so we stay in sync with whatever the config
+  # says (rather than hard-coding it here and drifting out of date).
+  # Combining to_the_limit(low = TRUE) and to_the_limit(low = FALSE)
+  # across every `downloads_1yr` row picks up boundaries expressed as
+  # `< X`, `> X`, `<= X`, `>= X`, and `dplyr::between(., a, b)` alike.
+  # Compound conditions like `is.na(.x) | .x < X` return NA from
+  # to_the_limit() and are silently ignored -- as long as one of the
+  # other rows for the same metric names an upper boundary (e.g. Low's
+  # `> 200000` or Medium's `between(80000, 200000)`), we'll pick up the
+  # 200k ceiling. The bypass fires for any `pass_primary` member whose
+  # downloads_1yr sits below that ceiling, because they'd otherwise
+  # land in Medium/High on downloads alone and fail `accept_cats: Low`
+  # -- the whole point of the bypass is to give them their day in
+  # court. If nothing is parseable, we fall back to Inf so the bypass
+  # behaves as it did before this guard was added (applies to any
+  # `pass_primary` member). See #112.
   dwnld_conds  <- dec_df$condition[tolower(dec_df$metric) == "downloads_1yr"]
   dwnld_bounds <- c(
     to_the_limit(dwnld_conds, low = TRUE),
     to_the_limit(dwnld_conds, low = FALSE)
   )
   dwnld_bounds <- dwnld_bounds[is.finite(dwnld_bounds) & dwnld_bounds > 0]
-  min_dwnld_bound <- if (length(dwnld_bounds)) min(dwnld_bounds) else Inf
+  low_tier_min <- if (length(dwnld_bounds)) max(dwnld_bounds) else Inf
 
   subset_metrics <- dec_df |>
     dplyr::filter(tolower(metric_type) == tolower(label)) %>%
 
     # if this is not a CRAN pkg OR if it's a pkg that has been granted "pass-primary" status
     # (usually pkgs with lower downloads, but need a fair shake) AND its
-    # downloads_1yr is still below the lowest primary bound
-    # (min_dwnld_bound; see above)...
+    # downloads_1yr is still below the Low tier's floor
+    # (low_tier_min; see above)...
     # then do not use downloads_1yr as the cornerstone primary metric
     {if("downloads_1yr" %in% all_mets &&
         (toupper(repo_name) != "CRAN" ||
          (pkgs_df$package %in% bypass_primary &
           (is.na(pkgs_df$downloads_1yr) |
-           pkgs_df$downloads_1yr < min_dwnld_bound)))
+           pkgs_df$downloads_1yr < low_tier_min)))
          ) {
       dplyr::filter(., !(tolower(metric) %in% c("downloads_1yr")))
     } else .} |>

--- a/tests/testthat/test-rip_cats_by_pkg.R
+++ b/tests/testthat/test-rip_cats_by_pkg.R
@@ -114,6 +114,99 @@ test_that("rip_cats_by_pkg() processes data with matching metric types", {
 })
 
 
+test_that("rip_cats_by_pkg() bypass fires for pass_primary members below the Low tier's floor (#112)", {
+  # Config-shaped downloads_1yr rule with bounds at 80k (High/Medium
+  # boundary) and 200k (Medium/Low boundary). Under #112 the bypass
+  # fires when a pass_primary member's downloads sit below the *Low*
+  # tier's floor (200k), not just below the High tier's ceiling (80k),
+  # because a pkg between 80k and 200k still lands in Medium and fails
+  # `accept_cats: Low` on its own -- the whole point of the bypass is
+  # to save those pkgs from the primary-metric axe.
+  mock_dec_df <- data.frame(
+    metric = "downloads_1yr",
+    metric_type = "primary",
+    decision = factor(c("High", "Medium", "Low"),
+                      levels = c("Low", "Medium", "High")),
+    decision_id = c(3, 2, 1),
+    condition = c("~ is.na(.x) | .x < 80000",
+                  "~ dplyr::between(.x, 80000, 200000)",
+                  "~ .x > 200000"),
+    auto_accept = c(NA_character_, NA_character_, "~ .x > 1000000"),
+    stringsAsFactors = FALSE
+  )
+
+  # `bypass_pkg` is on the pass_primary list with 100k downloads (mid-
+  # tier: Medium under the config). Pre-#112 it would NOT be bypassed
+  # (100k >= 80k). Post-#112 it IS bypassed (100k < 200k), so
+  # downloads_1yr should be dropped from the primary metric set.
+  mock_pkgs <- data.frame(
+    package = "bypass_pkg",
+    downloads_1yr = 100000L,
+    stringsAsFactors = FALSE
+  )
+
+  testthat::local_mocked_bindings(
+    pull_config = function(val = NULL, rule_type = NULL, config_path = NULL) {
+      if (identical(val, "pass_primary")) "bypass_pkg" else NULL
+    }
+  )
+
+  expect_output(
+    result <- rip_cats_by_pkg(
+      label = "primary",
+      repo_name = "CRAN",
+      dec_df = mock_dec_df,
+      pkgs_df = mock_pkgs,
+      decisions = c("Low", "Medium", "High"),
+      else_cat = "High"
+    )
+  )
+  # Bypass fired: downloads_1yr should no longer appear in the primary
+  # categorisation output.
+  expect_false("downloads_1yr_cat" %in% names(result))
+})
+
+test_that("rip_cats_by_pkg() bypass does NOT fire when pass_primary member exceeds Low tier's floor (#112)", {
+  # Same config, but pkg has 250k downloads -- already in Low tier
+  # under downloads_1yr alone. Bypass should NOT fire, so
+  # downloads_1yr stays in the primary set.
+  mock_dec_df <- data.frame(
+    metric = "downloads_1yr",
+    metric_type = "primary",
+    decision = factor(c("High", "Medium", "Low"),
+                      levels = c("Low", "Medium", "High")),
+    decision_id = c(3, 2, 1),
+    condition = c("~ is.na(.x) | .x < 80000",
+                  "~ dplyr::between(.x, 80000, 200000)",
+                  "~ .x > 200000"),
+    auto_accept = c(NA_character_, NA_character_, "~ .x > 1000000"),
+    stringsAsFactors = FALSE
+  )
+  mock_pkgs <- data.frame(
+    package = "popular_pkg",
+    downloads_1yr = 250000L,
+    stringsAsFactors = FALSE
+  )
+  testthat::local_mocked_bindings(
+    pull_config = function(val = NULL, rule_type = NULL, config_path = NULL) {
+      if (identical(val, "pass_primary")) "popular_pkg" else NULL
+    }
+  )
+  expect_output(
+    result <- rip_cats_by_pkg(
+      label = "primary",
+      repo_name = "CRAN",
+      dec_df = mock_dec_df,
+      pkgs_df = mock_pkgs,
+      decisions = c("Low", "Medium", "High"),
+      else_cat = "High"
+    )
+  )
+  # Bypass did NOT fire: downloads_1yr should still appear.
+  expect_true("downloads_1yr_cat" %in% names(result))
+})
+
+
 test_that("rip_cats_by_pkg() filters 'downloads_1yr' for non-CRAN repos", {
   
   metric_name = "other_metric"


### PR DESCRIPTION
Closes #112.

## Problem

`rip_cats_by_pkg()`'s `pass_primary` bypass drops `downloads_1yr` from the primary metric set for pass_primary members whose downloads sit below a threshold parsed from the `downloads_1yr` config rule. The threshold was `min()` over the parseable bounds -- 80k under the default config (High/Medium boundary). But a pkg between 80k and 200k still lands in Medium on `downloads_1yr` alone and fails `accept_cats: Low`, so the bypass never actually saves those pkgs. That's the entire point of the allow-list.

## Fix

Switch `min()` → `max()` so the threshold is the *upper* bound (Medium/Low boundary, 200k under the default config) -- i.e. the Low tier's floor. Now any pass_primary member whose downloads would put it below Low on that metric alone gets the bypass.

Renamed the local var `min_dwnld_bound` → `low_tier_min` and updated the surrounding comment block to describe the intent.

## Tests

Two new tests in `test-rip_cats_by_pkg.R` using `local_mocked_bindings(pull_config = ...)`:

- pass_primary member with 100k downloads (Medium under default bounds) → bypass fires, `downloads_1yr_cat` absent from result.
- pass_primary member with 250k downloads (Low tier) → bypass does not fire, `downloads_1yr_cat` present.

Full suite: 777 pass. Pre-existing `test-bioc-remote-initial-metrics.R` failure is unrelated (fails on main too).