### PR TITLE
Show source repo URL in per-package report Context (#114)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.23
+Version: 0.1.23.9001
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,11 @@
   below the *High* tier's ceiling (lower bound, e.g. 80k). Packages in
   the Medium tier would still land in Medium on `downloads_1yr` alone
   and fail `accept_cats: Low`, defeating the point of the bypass. (#112)
+- Added the package's source repo URL as a bullet in the Context section
+  of the per-package report (`inst/report/package/pkg_template.qmd`).
+  The URL's basename is the snapshot repo name in Posit Package Manager,
+  so reviewers can trace a rendered report back to a specific PPM
+  snapshot without cross-referencing `qual_metadata.rds`. (#114)
 
 # val.pipeline 0.1.21
 

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -696,6 +696,7 @@ val_pkg <- function(
         assessment_path = assessment_file,
         hide_reverse_deps = 'false',
         source = src_ref, # defined above
+        repo_url = repo_src,
         val_date = as.character(val_date),
         val_dir = out_dir
       ),

--- a/inst/report/package/pkg_template.qmd
+++ b/inst/report/package/pkg_template.qmd
@@ -9,6 +9,7 @@ params:
   assessment_path: "assessments/dplyr.rds"
   hide_reverse_deps: true
   source: "pkg_install"
+  repo_url: NULL
   val_date: NULL
   val_dir: NULL
 format:
@@ -58,6 +59,7 @@ risk_path <- params$assessment_path
 image <- params$image
 val_date <- params$val_date
 val_dir <- params$val_dir
+repo_url <- params$repo_url
 
 d_riskmetric <- readRDS(risk_path)
 
@@ -86,6 +88,14 @@ cat("> - **Validation directory (`val_dir`):** ",
 cat("> - **Origin (`source`):** ",
     riskreports:::get_pkg_origin(params$source),
     "\n", sep = "")
+# Source repo URL. This is the actual URL the package tarball was
+# pulled from during the run (e.g. a date-pinned PPM snapshot). Its
+# basename is the snapshot repo name in Posit Package Manager, so
+# reviewers can trace a rendered report back to a specific PPM
+# snapshot without cross-referencing `qual_metadata.rds`. (#114)
+if (!is.null(repo_url) && length(repo_url) == 1L && nzchar(repo_url)) {
+  cat("> - **Source repo URL (`repo_url`):** ", repo_url, "\n", sep = "")
+}
 ```
 
 


### PR DESCRIPTION
Closes #114.

## Problem

The per-package report already shows the origin **category** (`CRAN`, `BioC`, `github_<org>`) via `riskreports:::get_pkg_origin(params$source)`, but not the **URL** of the repo the package tarball was pulled from. That URL's basename is the snapshot repo name in Posit Package Manager, so a reviewer looking at a rendered report can't tell which PPM snapshot the pkg would ship from without cross-referencing `qual_metadata.rds`.

## Fix

- `inst/report/package/pkg_template.qmd`: declare a new `repo_url` param (default `NULL`) and render it as a Context bullet immediately after the Origin bullet when supplied. Guarded on non-null/non-empty so legacy renders with an older `val_pkg()` still work.
- `R/val_pkg.R`: pass `repo_src` (already computed earlier in `val_pkg()` — the URL derived from the pkg's `Repository` field with `/src/contrib` stripped) as the new `repo_url` param on the `riskreports::package_report()` call.

## Verification

`devtools::test(filter = "val_pkg")` clean.