### PR TITLE
Catch per-package val_pkg() errors instead of cancelling the run (#116)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.24
+Version: 0.1.25
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,19 @@
 
+# val.pipeline 0.1.25
+
+- Caught errors thrown by `val_pkg()` inside `val_build()`'s per-package
+  assessment loop so a single package blowing up (e.g. a
+  `build_decisions_df()` "None of the metrics in 'rule_lst' are viable"
+  error when a package's viable-metric set collapses) no longer cancels
+  the whole multi-hour run. The erroring package is marked with the
+  highest risk tier, `decision_reason = "Error"`, and the error message
+  goes into `decision_reason_note`; the failure is also logged at
+  `minimal` verbosity so it surfaces regardless of `verbose` setting.
+  Downstream `reject_iteration()` propagates the failure to dependents
+  as it would for any other failed package. The summary report gained a
+  new "Packages that errored during assessment" section listing every
+  such package + its captured error text. (#116)
+
 # val.pipeline 0.1.24
 
 - Added optional reverse-dependency expansion to `resolve_pkg_tree()`,

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -372,16 +372,76 @@ val_build <- function(
 
     if (!is_dep_skip) {
       if (!file.exists(pkg_meta_file) | replace) {
-        pkg_meta <- val_pkg(
-          pkg = pkg,
-          ver = ver,
-          avail_pkgs = avail_pkgs,
-          ref = if(pkg %in% remote_pkgs) 'remote' else ref,
-          metric_pkg = metric_pkg,
-          out_dir = val_dir,
-          val_date = val_date,
-          pkg_idx = pkg_cnt,
-          pkg_total = pkgs_length)
+        pkg_meta <- tryCatch(
+          val_pkg(
+            pkg = pkg,
+            ver = ver,
+            avail_pkgs = avail_pkgs,
+            ref = if(pkg %in% remote_pkgs) 'remote' else ref,
+            metric_pkg = metric_pkg,
+            out_dir = val_dir,
+            val_date = val_date,
+            pkg_idx = pkg_cnt,
+            pkg_total = pkgs_length),
+          error = function(e) {
+            # Don't cancel the whole run just because one pkg blew up
+            # somewhere deep in val_pkg() (build_decisions_df() with a
+            # collapsed viable-metric set, a covr crash, a corrupt
+            # tarball, etc.). Synthesize a High-tier `pkg_meta`
+            # bundle keyed on `decision_reason = "Error"` with the
+            # captured error message in `decision_reason_note`, save it
+            # to disk so downstream collation still sees this pkg, and
+            # log the failure at `minimal` so it surfaces even when the
+            # caller has muted normal-tier output. Dependents of the
+            # erroring pkg get downgraded via reject_iteration() in
+            # val_finalize() thanks to the pkg landing in `failed_pkgs`
+            # below. See #116.
+            err_msg <- conditionMessage(e)
+            val_msg(paste0("\n\n--> ERROR while assessing ", pkg, " v", ver,
+                           ": ", err_msg,
+                           "\n     Marking risk as '",
+                           decisions[length(decisions)],
+                           "' and continuing with the next package.\n\n"),
+                    min_level = "minimal")
+            repo_src <- avail_pkgs |>
+              dplyr::filter(Package %in% pkg) |>
+              dplyr::pull(Repository) |>
+              dirname() |> dirname()
+            repo_name <- tryCatch(
+              get_repo_origin(repo_src = repo_src, pkg_name = pkg),
+              error = function(e2) NA_character_
+            )
+            err_meta <- list(
+              pkg = pkg,
+              ver = ver,
+              r_ver = getRversion(),
+              sys_info = list(R.Version()),
+              repos = repo_name,
+              val_date = val_date,
+              ref = NA_character_,
+              metric_pkg = NA_character_,
+              decision = decisions[length(decisions)],
+              decision_reason = "Error",
+              decision_reason_note = err_msg,
+              final_decision = decisions[length(decisions)],
+              final_decision_reason = "Error",
+              final_decision_reason_note = err_msg,
+              depends = NA_character_,
+              suggests = NA_character_,
+              depends_direct  = NA_character_,
+              suggests_direct = NA_character_,
+              rev_deps = NA_character_,
+              assessment_runtime = list(txt = NA_character_, mins = NA)
+            )
+            tryCatch(saveRDS(err_meta, pkg_meta_file),
+                     error = function(e3) invisible(NULL))
+            val_pkg_summary_line(pkg, ver, err_meta$decision,
+                                 suffix = "(error)",
+                                 pkg_idx = pkg_cnt,
+                                 pkg_total = pkgs_length)
+            err_meta
+          }
+        )
       } else {
         val_msg(paste0("\nAttempted New Package: ", pkg, " v", ver,", but already assessed.\n\n"),
                 min_level = "normal")

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -425,6 +425,36 @@ if (nrow(preapp_bad) > 0L) {
 }
 ```
 
+## Packages that errored during assessment
+
+Packages whose per-package assessment (`val_pkg()`) threw an error mid-run
+(e.g. an internal helper collapsing on an unexpected metric shape, a
+corrupt tarball, a covr crash). Rather than cancelling the whole build,
+`val_build()` catches the error, assigns the highest risk tier, records
+the error message as the decision reason note, and continues with the
+next package. See #116.
+
+```{r errored-pkgs}
+errored <- qual_metadata |>
+  dplyr::filter(final_decision_reason == "Error") |>
+  dplyr::arrange(pkg) |>
+  dplyr::transmute(
+    Package = pkg,
+    Version = ver,
+    Error = ifelse(is.na(final_decision_reason_note) |
+                     final_decision_reason_note == "",
+                   "(unrecorded)", final_decision_reason_note)
+  )
+```
+
+**`r nrow(errored)`** package(s) errored during assessment in this run.
+
+```{r errored-pkgs-tbl}
+if (nrow(errored) > 0L) {
+  itable(errored, default_page_size = 25)
+}
+```
+
 # Packages by Risk Category
 
 The tables below list every package in each risk tier, with the reason and

--- a/tests/testthat/test-val_build.R
+++ b/tests/testthat/test-val_build.R
@@ -141,3 +141,31 @@ test_that("val_build() creates directory structure", {
     })
   )
 })
+
+test_that("val_build() wraps val_pkg() in tryCatch so one pkg's error doesn't cancel the run (#116)", {
+  # Source-level guard. The behaviour (catch val_pkg() errors,
+  # synthesize a High-tier meta with decision_reason = 'Error', save
+  # to disk, keep going) can't be exercised in-process without
+  # standing up a full val_prep + mocked assess pipeline, so pin the
+  # invariant against the source: the tryCatch has to wrap the
+  # val_pkg() call and the error handler has to set 'Error' as the
+  # decision_reason and put the error message in the note.
+  vb <- system.file("R", "val_build.R", package = "val.pipeline")
+  if (!nzchar(vb) || !file.exists(vb)) {
+    vb <- file.path("..", "..", "R", "val_build.R")
+  }
+  skip_if_not(file.exists(vb), "val_build.R not found")
+  src <- paste(readLines(vb, warn = FALSE), collapse = "\n")
+
+  # tryCatch wraps val_pkg() with an error handler.
+  expect_match(src, "tryCatch\\([^)]*val_pkg\\(", perl = TRUE)
+  # Error handler surfaces decision_reason = 'Error' and stashes the
+  # error text in decision_reason_note.
+  expect_true(grepl('decision_reason = "Error"', src, fixed = TRUE))
+  expect_true(grepl('final_decision_reason = "Error"', src, fixed = TRUE))
+  expect_match(src, "conditionMessage\\(e\\)")
+  # (error) suffix on the summary line so it visually stands out.
+  expect_true(grepl('suffix = "(error)"', src, fixed = TRUE))
+  # Log line goes out at minimal so `verbose = "minimal"` still sees it.
+  expect_true(grepl("ERROR while assessing", src, fixed = TRUE))
+})

--- a/tests/testthat/test-val_pipeline_report.R
+++ b/tests/testthat/test-val_pipeline_report.R
@@ -428,6 +428,28 @@ test_that("summary_template includes Pre-Approved (dep failed) section (#110)", 
   expect_match(src, "preapp_bad\\s*<-")
 })
 
+test_that("summary_template includes errored-packages section (#116)", {
+  # Source-level guard mirroring the Pre-Approved guard above. When
+  # val_pkg() throws mid-run val_build() now catches the error and
+  # records `final_decision_reason = "Error"` with the error message in
+  # the note; the summary template surfaces those pkgs in a dedicated
+  # section so operators can see the failures at a glance.
+  qmd <- system.file(
+    "report", "summary", "summary_template.qmd",
+    package = "val.pipeline"
+  )
+  if (!nzchar(qmd) || !file.exists(qmd)) {
+    qmd <- file.path("..", "..", "inst", "report", "summary",
+                     "summary_template.qmd")
+  }
+  skip_if_not(file.exists(qmd), "summary_template.qmd not found")
+  src <- paste(readLines(qmd, warn = FALSE), collapse = "\n")
+  expect_true(grepl("Packages that errored during assessment",
+                    src, fixed = TRUE))
+  expect_match(src, "errored\\s*<-")
+  expect_true(grepl("final_decision_reason == \"Error\"", src, fixed = TRUE))
+})
+
 test_that("summary_template gates dropped-packages table on HTML output", {
   # Source-level guard: the per-package dropped table is intentionally
   # omitted from PDF renders because a full CRAN-scale run can produce a


### PR DESCRIPTION
Closes #116.

## Problem

If `val_pkg()` throws mid-run (the reported case: `build_decisions_df()` complaining that "None of the metrics in 'rule_lst' are viable" when a package's viable-metric set collapses; other realistic paths: a covr crash, a corrupt tarball, an upstream metric-fn regression), the exception used to bubble all the way out of `val_build()`'s per-package loop and cancel the whole multi-hour run. Every previously-assessed package's `_meta.rds` was already on disk but the pipeline never reached collation or reporting.

## Fix

Wrap the `val_pkg()` call inside `assess_one()` in `tryCatch()`. On error, synthesize a High-tier `pkg_meta` bundle:

| field | value |
| --- | --- |
| `decision` / `final_decision` | `decisions[length(decisions)]` (`"High"` under default config) |
| `decision_reason` / `final_decision_reason` | `"Error"` |
| `decision_reason_note` / `final_decision_reason_note` | `conditionMessage(e)` |

The synthesized bundle is saved to `assessed/<pkg>_<ver>_meta.rds` so downstream collation still picks up the pkg, and the error is logged at `min_level = "minimal"` so it shows up regardless of the caller's `verbose` setting. The per-package summary line renders with an `(error)` suffix. `reject_iteration()` propagates the failure to dependents just like any other failed pkg (the erroring pkg lands in `failed_pkgs` because its `final_decision != decisions[1]`).

Parallel mode (`workers > 1`) is automatically covered — `assess_one()` now returns the synth bundle from `tryCatch` instead of propagating, so `future.apply::future_mapply` doesn't blow up either.

## Report

Added a new **Packages that errored during assessment** section to `inst/report/summary/summary_template.qmd`, mirroring the shape of the recently-added Pre-Approved-dep-failed section: a count sentence + a filterable table with Package / Version / Error columns. Empty case renders just the count.

## Tests

- `test-val_build.R`: source-level guard on the `tryCatch` shape, error-reason strings, and (error) suffix.
- `test-val_pipeline_report.R`: source-level guard on the new report section.
- Full suite: FAIL 2 | WARN 53 | SKIP 1 | PASS 792 — the 2 fails are the pre-existing `test-bioc-remote-initial-metrics` ones, unrelated.

## Version + NEWS

- `DESCRIPTION`: 0.1.24 → 0.1.25.
- `NEWS.md`: new `# val.pipeline 0.1.25` heading with a single bullet.