### PR TITLE
Guard val_build(workers > 1) against silent worker early-exit (#120)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,29 @@
   new "Packages that errored during assessment" section listing every
   such package + its captured error text. (#116)
 
+# val.pipeline 0.1.25
+
+- Hardened `val_build()`'s parallel branch (`workers > 1`) against
+  silent early exits. `future.apply::future_mapply()` used the
+  default `future.scheduling`, which pre-partitions all pending
+  packages into ~`workers`-many chunks; a single worker's R
+  subprocess dying mid-chunk (OOM-killed, segfault, walltime hit,
+  etc.) dropped every remaining package in that chunk on the floor
+  and, depending on the future version, either raised a
+  `FutureError` that never surfaced to `val_build()` or was absorbed
+  silently, leaving the parent to hand a truncated on-disk set to
+  `val_finalize()` and produce a partial `qual_metadata.rds` with
+  the Workbench job showing success. Two fixes:
+  1. Pin `future.scheduling = 1L` so a worker death loses at most
+     the single package it was actively assessing; healthy workers
+     pick up the rest.
+  2. After `future_mapply` returns, recount `_meta.rds` files on
+     disk against what was dispatched; if fewer landed than
+     expected, stop with a clear error so `val_finalize()` doesn't
+     collate a truncated cohort silently. Re-run with `replace =
+     FALSE` to resume.
+  (#120)
+
 # val.pipeline 0.1.24
 
 - Added optional reverse-dependency expansion to `resolve_pkg_tree()`,

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -647,8 +647,45 @@ val_build <- function(
         pkg_cnt = todo,
         SIMPLIFY  = FALSE,
         USE.NAMES = FALSE,
-        future.seed = TRUE
+        future.seed = TRUE,
+        # Tight per-element scheduling: dispatch one pkg per future
+        # rather than pre-partitioning `todo` into ~`workers`-many
+        # chunks. A worker segfaulting or OOM-killed mid-chunk under
+        # the default chunk-size drops every remaining pkg in that
+        # chunk on the floor -- sometimes silently, sometimes with a
+        # FutureError depending on the future version -- and the
+        # parent's mapply return-value structure doesn't surface the
+        # loss to val_build(). With one-pkg-per-future, a worker
+        # death only loses the single pkg it was actively assessing;
+        # any others reassigned to a healthy worker still run. See
+        # #120.
+        future.scheduling = 1L
       )
+      # Disk-state guard. Even with `future.scheduling = 1L`, a mass
+      # worker die-off (e.g. OOM-killer sweeping all sessions) can
+      # leave `future_mapply` returning "successfully" (or absorbing
+      # the FutureErrors into its results structure) while the parent
+      # never realizes only a fraction of `todo` finished. Recount
+      # `_meta.rds` files on disk against what we dispatched; if the
+      # gap is non-zero raise so val_finalize() doesn't collate a
+      # truncated qual_metadata.rds silently. See #120.
+      post_meta <- file.path(assessed,
+                             paste0(paste(pkgs[todo], vers[todo],
+                                          sep = "_"), "_meta.rds"))
+      landed <- sum(file.exists(post_meta))
+      if (landed < length(todo)) {
+        missing_n <- length(todo) - landed
+        stop("val_build(workers = ", workers, "): future_mapply returned ",
+             "but only ", landed, " of ", length(todo),
+             " dispatched package(s) have a `_meta.rds` on disk. ",
+             missing_n, " package(s) never completed -- ",
+             "typically a worker was OOM-killed or the parent process ",
+             "hit a walltime mid-run. Re-run val_pipeline() (or ",
+             "val_build()) with the same args and `replace = FALSE` to ",
+             "pick up where this run left off; the already-assessed ",
+             "packages will be skipped. See #120.",
+             call. = FALSE)
+      }
     } else {
       val_msg(paste0("\n--> All ", pkgs_length,
                      " package(s) already assessed on disk; ",

--- a/tests/testthat/test-val_build.R
+++ b/tests/testthat/test-val_build.R
@@ -169,3 +169,27 @@ test_that("val_build() wraps val_pkg() in tryCatch so one pkg's error doesn't ca
   # Log line goes out at minimal so `verbose = "minimal"` still sees it.
   expect_true(grepl("ERROR while assessing", src, fixed = TRUE))
 })
+
+test_that("val_build() parallel branch pins future.scheduling=1L and guards disk-state (#120)", {
+  # Source-level guard. The behaviour (fine-grained per-pkg dispatch +
+  # post-mapply file-count check that stops the run when future_mapply
+  # returned but pkgs are missing on disk) can't be exercised without
+  # standing up a real multisession + failure injection, so pin the
+  # invariant at the source level.
+  vb <- system.file("R", "val_build.R", package = "val.pipeline")
+  if (!nzchar(vb) || !file.exists(vb)) {
+    vb <- file.path("..", "..", "R", "val_build.R")
+  }
+  skip_if_not(file.exists(vb), "val_build.R not found")
+  src <- paste(readLines(vb, warn = FALSE), collapse = "\n")
+
+  # Fine-grained scheduling so a worker's death loses at most one pkg.
+  expect_match(src, "future\\.scheduling = 1L")
+  # Post-mapply file-count guard.
+  expect_match(src, "post_meta\\s*<-")
+  expect_match(src, "landed\\s*<-\\s*sum\\(file.exists\\(post_meta\\)\\)")
+  # And it stops (not warns) when short, so val_finalize doesn't
+  # collate a truncated qual_metadata silently.
+  expect_true(grepl("stop(\"val_build(workers = \", workers,",
+                    src, fixed = TRUE))
+})


### PR DESCRIPTION
Closes #120.

## Symptom

Aaron ran the pipeline with `workers = 6`; the Workbench job reported success; `val_finalize()` collated a truncated `qual_metadata.rds`. Only ~194 of 1606 packages had actually been assessed.

## Diagnosis

Post-mortem on the aborted run's `assessed/`:

- All four per-pkg artifacts (`_meta.rds`, `_assess_record.rds`, `_assessments.rds`, `_scores.rds`) agreed at ~194 → whatever workers finished, they finished cleanly. No mid-`val_pkg()` crashes.
- No `.render_*/` scratch dirs → no worker died mid-report.
- `_meta.rds` mtimes tapered off gradually (64 → 60 → 58 → 12 → 0 per hour over ~4 hours) rather than dropping abruptly → workers finished the packages already assigned to them, but no new packages were dispatched.

That's the fingerprint of `future.apply::future_mapply`'s default `future.scheduling`: elements get pre-partitioned into ~`workers`-many chunks at dispatch. A worker's R subprocess dying mid-chunk (OOM-killed, walltime-hit, segfault) drops every remaining package in that chunk on the floor. Depending on the future version, this either raises a `FutureError` that never surfaces to `val_build()` or gets absorbed into the mapply return structure. Either way, the parent proceeds to finalization thinking everything's fine.

## Fix

Two-part guard, both in `R/val_build.R`'s `workers > 1` branch:

1. **`future.scheduling = 1L`** on the `future_mapply` call. Each package becomes its own future, so a worker's death loses at most the one package it was actively assessing — any packages it hadn't picked up yet stay queued for healthy workers.
2. **Disk-state guard** immediately after `future_mapply` returns. Recount `<pkg>_<ver>_meta.rds` files against the dispatched `todo` set; if fewer landed than expected, `stop()` with a message naming the delta and pointing at `replace = FALSE` re-run. `val_finalize()` never gets a truncated cohort silently.

Serial branch is unchanged (the `for` loop was already pkg-by-pkg).

## Tests

Source-level guard test verifying both changes (`future.scheduling = 1L` is set + the post-mapply file-count guard exists and raises via `stop()`).

Full suite: FAIL 2 | WARN 53 | SKIP 1 | PASS 796 — the 2 fails are the pre-existing `test-bioc-remote-initial-metrics` ones, unrelated.

## Version + NEWS

- `DESCRIPTION`: 0.1.24 → 0.1.25.
- `NEWS.md`: bullet under new `# val.pipeline 0.1.25` heading.