### PR TITLE
Guard val_build() against NA decisions + surface incomplete assessments in report (#124)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.26
+Version: 0.1.27
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,23 @@
 
+# val.pipeline 0.1.27
+
+- Guarded `val_build()`'s serial-branch dep-propagation check against
+  `NA` decisions from `val_pkg()`. Previously, when `val_decision()`'s
+  rule ladder produced no category (typically a `remote_only` or Bioc
+  package with a shrunken viable-metric set), `pkg_meta$decision` came
+  back `NA`, the `!= decisions[1]` comparison evaluated to `NA`, and
+  the whole run took an "missing value where TRUE/FALSE needed" halt
+  near the tail. `val_pkg()` now stashes an `assessment_gaps` list on
+  the meta bundle (viable metrics, per-metric categories, primary /
+  secondary risk categories, synthesized note) and flips
+  `decision_reason` to `"Incomplete Assessment"`. Decisions themselves
+  stay `NA` — no silent coercion to a tier. `val_finalize()` preserves
+  the diagnostic as a list-col on `qual_metadata`, and the summary
+  report gained a "Packages with incomplete assessment" table plus a
+  per-package appendix section with viable metrics, per-metric
+  categories, and cross-joined actual scores from `qual_assessments`.
+  (#124)
+
 # val.pipeline 0.1.26
 
 - Added per-package memory watchdog observability so `workers` on

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -800,7 +800,26 @@ val_build <- function(
       pkg_meta <- assess_one(pkg, ver, i,
                              is_dep_skip = is_dep_skip,
                              failed_snapshot = failed_pkgs)
-      if (!is_dep_skip && pkg_meta$decision != decisions[1]) {
+      # Silent-NA guard. When val_decision()'s rule ladder collapses
+      # for a pkg (typically remote_only pkgs with a shrunken
+      # viable-metric set), it returns final_risk = NA without
+      # throwing; val_pkg() then persists a bundle with decision = NA.
+      # Without this guard, the ! = comparison below evaluates to NA
+      # and takes the whole run down. Skip dep propagation for the
+      # NA pkg and log at minimal; the report will surface it under
+      # "Packages with incomplete assessment". reject_iteration() at
+      # finalize time treats NA decisions as non-failing rather than
+      # cascading them into dep-driven downgrades. See #124.
+      if (!is_dep_skip && is.na(pkg_meta$decision)) {
+        val_msg(paste0("\n\n--> WARNING: ", pkg, " v", ver,
+                       " has NA decision on its meta bundle ",
+                       "(rule ladder produced no category). ",
+                       "Skipping dep propagation for this pkg; ",
+                       "see the summary report's ",
+                       "'Packages with incomplete assessment' ",
+                       "section for details.\n\n"),
+                min_level = "minimal")
+      } else if (!is_dep_skip && pkg_meta$decision != decisions[1]) {
         val_msg(paste0("\n\n--> ", pkg, " v", ver," was assessed with a '",
                        pkg_meta$decision,"' risk. All packages that depend on it will also be marked as '",
                        decisions[length(decisions)],"' risk.\n\n"),

--- a/R/val_finalize.R
+++ b/R/val_finalize.R
@@ -269,6 +269,15 @@ val_finalize <- function(
     bundle <- readRDS(file.path(assessed, meta_files[[i]]))
     tmap <- bundle[["timings"]]
     bundle[["timings"]] <- NULL
+    # Pull `assessment_gaps` out before `list_flatten()` so it stays a
+    # single list-col instead of exploding into ~5 nested columns
+    # (viable_metrics, metric_cats, ...). Populated by val_pkg() when
+    # val_decision() couldn't emit a category for a pkg (typically a
+    # remote_only pkg with a shrunken viable-metric set). Absent on
+    # older bundles -> NULL. Report reads it back list-of-lists via
+    # `qual_metadata$assessment_gaps[[i]]`. See #124.
+    gaps <- bundle[["assessment_gaps"]]
+    bundle[["assessment_gaps"]] <- NULL
 
     x <- purrr::list_flatten(bundle)
     x$depends  <- list(x$depends)
@@ -282,6 +291,7 @@ val_finalize <- function(
     x$suggests_direct <- list(x$suggests_direct)
     x$rev_deps <- list(x$rev_deps)
     x$sys_info <- list(x$sys_info)
+    x$assessment_gaps <- list(gaps)
     pkgs_df0_rows[[i]] <- dplyr::as_tibble(x)
 
     if (!is.null(tmap) && length(tmap) > 0L) {

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -654,6 +654,64 @@ val_pkg <- function(
     .default = NA_character_
   )
 
+  # Silent-NA capture. val_decision() can return final_risk = NA when
+  # its rule ladder produces no category for this pkg — typically a
+  # remote_only pkg whose shrunken viable-metric set means the primary
+  # rules score `unknown` AND the secondary rules also don't match.
+  # Preserve `decision = NA` per operator preference (don't silently
+  # coerce to a tier), but overwrite decision_reason with a distinct
+  # tag ("Incomplete Assessment") and stash an `assessment_gaps` list
+  # so the summary report can surface which metrics were viable,
+  # which categories fired, and why the ladder produced nothing. See
+  # #124.
+  assessment_gaps <- NULL
+  if (is.na(decision$final_risk)) {
+    metric_cat_cols <- names(decision)[
+      grepl("_cat$", names(decision), perl = TRUE) &
+      !grepl("cataa$", names(decision), perl = TRUE)
+    ]
+    metric_cats <- if (length(metric_cat_cols) > 0L) {
+      vapply(metric_cat_cols,
+             function(c) as.character(decision[[c]][1]),
+             character(1))
+    } else {
+      character(0)
+    }
+    prim_cat <- if ("primary_risk_category" %in% names(decision)) {
+      as.character(decision$primary_risk_category[1])
+    } else {
+      NA_character_
+    }
+    sec_cat <- if ("secondary_risk_category" %in% names(decision)) {
+      as.character(decision$secondary_risk_category[1])
+    } else {
+      NA_character_
+    }
+    note <- if (identical(prim_cat, "unknown") &&
+                  (is.na(sec_cat) || identical(sec_cat, "unknown"))) {
+      paste0("Primary rule ladder scored 'unknown' and secondary ",
+             "rule ladder also produced no category. Typically a ",
+             "remote_only / Bioc pkg whose viable-metric set is too ",
+             "thin to trigger any rule.")
+    } else if (identical(prim_cat, "unknown")) {
+      paste0("Primary rule ladder scored 'unknown'; ",
+             "secondary rule ladder produced no matching category.")
+    } else {
+      paste0("Rule ladder produced no matching category ",
+             "(primary = '", prim_cat, "', ",
+             "secondary = '", sec_cat, "').")
+    }
+    assessment_gaps <- list(
+      viable_metrics          = viable_metrics,
+      metric_cats             = metric_cats,
+      primary_risk_category   = prim_cat,
+      secondary_risk_category = sec_cat,
+      note                    = note
+    )
+    decision_reason      <- "Incomplete Assessment"
+    decision_reason_note <- note
+  }
+
   val_msg("\n-->", pkg_v,"decision reason:\n---->", decision_reason, "\n",
           min_level = "normal")
   if(!is.na(decision_reason_note)) {
@@ -749,6 +807,11 @@ val_pkg <- function(
     suggests_direct = if(identical(suggests_direct, character(0))) NA_character_ else suggests_direct,
     rev_deps = if(is.null(pkg_assessment$reverse_dependencies)) NA_character_ else pkg_assessment$reverse_dependencies |> as.vector(),
     assessment_runtime = list(txt = ass_mins_txt, mins = ass_mins),
+    # Diagnostic capture when val_decision()'s rule ladder produced
+    # `final_risk = NA` for this pkg -- populated in the "Silent-NA
+    # capture" block above. NULL for pkgs with a real decision. See
+    # #124.
+    assessment_gaps = assessment_gaps,
     # Per-phase elapsed seconds captured via val_time_block() around
     # the fat blocks (download, untar, assess_initial, assess_final,
     # decision, report). Named list; each value is a numeric vector

--- a/dev/dev_find_na_decision.R
+++ b/dev/dev_find_na_decision.R
@@ -1,0 +1,90 @@
+# dev/dev_find_na_decision.R
+#
+# Fast triage for the
+#   Error in if (!is_dep_skip && pkg_meta$decision != decisions[1]) { :
+#     missing value where TRUE/FALSE needed
+# blowup at the tail of a serial-mode val_build() rerun with
+# replace = FALSE. Root cause is a cached _meta.rds bundle whose
+# `decision` field is NA_character_, usually produced by a prior run
+# where val_decision() couldn't categorize the pkg (empty viable-metric
+# set, malformed assessment, etc.).
+#
+# Point `val_dir` at the run directory (the one containing
+# `assessed/`, `qual_metadata.rds` etc.) and source. Prints:
+#   * how many _meta.rds bundles are on disk
+#   * which ones have NA / NULL decision (the offenders)
+#   * a summary of what other key fields look like on those bundles,
+#     to help decide whether to delete + re-assess or hand-patch.
+#
+# No writes. Safe to re-run.
+
+val_dir <- "/data/shared/riskassessments/R_4.5.2/20260813"  # <-- adjust
+
+# ---- 1. Load every _meta.rds and record decision / final_decision. ----
+assessed <- file.path(val_dir, "assessed")
+stopifnot("assessed/ dir not found under val_dir" = dir.exists(assessed))
+
+files <- list.files(assessed, pattern = "_meta\\.rds$", full.names = TRUE)
+cat("Found", length(files), "_meta.rds file(s) under", assessed, "\n\n")
+
+status <- lapply(files, function(f) {
+  m <- tryCatch(readRDS(f), error = function(e) list(.err = conditionMessage(e)))
+  list(
+    file            = basename(f),
+    unreadable      = isTRUE(!is.null(m$.err)),
+    err_msg         = m$.err %||% NA_character_,
+    has_decision    = !is.null(m$decision),
+    decision        = if (is.null(m$decision)) NA_character_
+                      else as.character(m$decision)[1],
+    final_decision  = if (is.null(m$final_decision)) NA_character_
+                      else as.character(m$final_decision)[1],
+    decision_reason = if (is.null(m$decision_reason)) NA_character_
+                      else as.character(m$decision_reason)[1],
+    pkg             = m$pkg %||% NA_character_,
+    ver             = m$ver %||% NA_character_
+  )
+})
+`%||%` <- function(x, y) if (is.null(x)) y else x
+df <- do.call(rbind.data.frame, lapply(status, as.data.frame,
+                                       stringsAsFactors = FALSE))
+
+# ---- 2. The offenders. ----
+bad <- df$unreadable | !df$has_decision | is.na(df$decision)
+cat("Bundles with NA / NULL / unreadable decision:", sum(bad), "\n\n")
+
+if (any(bad)) {
+  print(df[bad, c("file", "pkg", "ver", "decision", "final_decision",
+                  "decision_reason", "unreadable", "err_msg")],
+        row.names = FALSE)
+} else {
+  cat("None found. If val_build() still blows up on the comparison,\n",
+      "the NA must be arriving from decisions[1] instead of pkg_meta$decision.\n",
+      "Check `pull_config(val = 'decisions_lst', rule_type = 'default')`\n",
+      "returns a character vector without NA.\n", sep = "")
+}
+
+# ---- 3. Options once you have the offender list. ----
+#
+# A. Delete offending _meta.rds file(s) so the next `val_pipeline(replace = FALSE)`
+#    re-assesses just those pkgs:
+#
+#      to_delete <- file.path(assessed, df$file[bad])
+#      # inspect first
+#      to_delete
+#      # then, only when you're sure:
+#      # file.remove(to_delete)
+#
+# B. Hand-patch the decision in-place (e.g. mark as High so the run finishes;
+#    reject_iteration() in val_finalize() will still propagate to dependents).
+#    Only do this when you know the pkg genuinely couldn't be assessed:
+#
+#      for (f in file.path(assessed, df$file[bad])) {
+#        m <- readRDS(f)
+#        m$decision              <- "High"
+#        m$decision_reason       <- m$decision_reason %||% "Error"
+#        m$decision_reason_note  <- m$decision_reason_note %||%
+#          "Manually patched from NA decision (see dev_find_na_decision.R)."
+#        # leave final_* fields alone; val_finalize()/reject_iteration()
+#        # will fill them in.
+#        saveRDS(m, f)
+#      }

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -456,6 +456,42 @@ if (nrow(errored) > 0L) {
 }
 ```
 
+## Packages with incomplete assessment
+
+Packages whose `val_decision()` rule ladder produced no category —
+typically a `remote_only` package with a shrunken viable-metric set,
+or a Bioc package where the initial-metrics whitelist was too thin.
+`decision` and `final_decision` are left as `NA` for these packages
+rather than silently coerced to a tier; per-package detail lives in
+the Appendix. See #124.
+
+```{r incomplete-pkgs}
+incomplete <- qual_metadata |>
+  dplyr::filter(is.na(final_decision) |
+                  final_decision_reason == "Incomplete Assessment") |>
+  dplyr::arrange(pkg) |>
+  dplyr::transmute(
+    Package = pkg,
+    Version = ver,
+    Source  = if ("repo_name" %in% names(qual_metadata))
+                as.character(repo_name) else NA_character_,
+    Reason  = ifelse(is.na(final_decision_reason) |
+                       final_decision_reason == "",
+                     "(unrecorded)", final_decision_reason),
+    Note    = ifelse(is.na(final_decision_reason_note) |
+                       final_decision_reason_note == "",
+                     "(no diagnostic)", final_decision_reason_note)
+  )
+```
+
+**`r nrow(incomplete)`** package(s) could not be categorized in this run.
+
+```{r incomplete-pkgs-tbl}
+if (nrow(incomplete) > 0L) {
+  itable(incomplete, default_page_size = 25)
+}
+```
+
 # Packages by Risk Category
 
 The tables below list every package in each risk tier, with the reason and
@@ -701,6 +737,80 @@ lic_tbl <- qa |>
   dplyr::mutate(percent = sprintf("%.1f%%", 100 * packages / sum(packages))) |>
   dplyr::rename(License = license, Packages = packages, Percent = percent)
 itable(lic_tbl, default_page_size = 15)
+```
+# Appendix: Incomplete Assessments
+
+For each package in the "Packages with incomplete assessment" table above,
+the diagnostic captured by `val_pkg()` at decision time: which metrics
+were viable, what per-metric risk category each one landed on, and the
+top-level primary/secondary category that the rule ladder emitted.
+Populated for runs post-#124; older runs will show "(not captured)".
+
+```{r incomplete-appendix, results = "asis"}
+if ("assessment_gaps" %in% names(qual_metadata)) {
+  gaps_rows <- which(
+    vapply(qual_metadata$assessment_gaps,
+           function(x) !is.null(x) && length(x) > 0L,
+           logical(1))
+  )
+} else {
+  gaps_rows <- integer(0)
+}
+
+if (length(gaps_rows) == 0L) {
+  cat("_(No packages with captured assessment gaps in this run.)_\n")
+} else {
+  qa_lookup <- if (exists("qa", inherits = FALSE) &&
+                     is.data.frame(qa) && "pkg" %in% names(qa)) qa else NULL
+  for (i in gaps_rows) {
+    pkg_i <- qual_metadata$pkg[i]
+    ver_i <- qual_metadata$ver[i]
+    g     <- qual_metadata$assessment_gaps[[i]]
+    cat(sprintf("## %s (v%s)\n\n", pkg_i, ver_i))
+    if (!is.null(g$note) && !is.na(g$note) && nzchar(g$note)) {
+      cat(g$note, "\n\n")
+    }
+    prim_cat_i <- g$primary_risk_category
+    if (is.null(prim_cat_i)) prim_cat_i <- NA
+    sec_cat_i <- g$secondary_risk_category
+    if (is.null(sec_cat_i)) sec_cat_i <- NA
+    cat(sprintf("- **Primary risk category**: `%s`\n", prim_cat_i))
+    cat(sprintf("- **Secondary risk category**: `%s`\n\n", sec_cat_i))
+
+    vm <- g$viable_metrics
+    mc <- g$metric_cats
+    if (length(mc) > 0L) {
+      metric_tbl <- tibble::tibble(
+        Metric   = sub("_cat$", "", names(mc)),
+        Category = as.character(unname(mc))
+      )
+      if (!is.null(qa_lookup)) {
+        qa_row <- qa_lookup[qa_lookup$pkg == pkg_i, , drop = FALSE]
+        if (nrow(qa_row) >= 1L) {
+          metric_tbl$Value <- vapply(metric_tbl$Metric, function(m) {
+            if (m %in% names(qa_row)) {
+              v <- qa_row[[m]][1]
+              if (is.null(v) || (length(v) == 1L && is.na(v))) return("NA")
+              format(v)
+            } else {
+              "(not in qual_assessments)"
+            }
+          }, character(1))
+        }
+      }
+      cat("**Per-metric outcomes:**\n\n")
+      print(kable(metric_tbl, align = "llr"))
+      cat("\n")
+    } else {
+      cat("_(No per-metric categories captured.)_\n\n")
+    }
+
+    if (length(vm) > 0L) {
+      cat("**Viable metrics (", length(vm), "):** `",
+          paste(vm, collapse = "`, `"), "`\n\n", sep = "")
+    }
+  }
+}
 ```
 
 # Appendix: Metric Thresholds

--- a/tests/testthat/test-val_build.R
+++ b/tests/testthat/test-val_build.R
@@ -247,3 +247,21 @@ test_that("restripe: round-robin interleaves the input order across workers", {
   gaps <- diff(out[1:8])
   expect_true(any(gaps >= 3L))
 })
+
+test_that("val_build serial branch guards against NA pkg_meta$decision (#124)", {
+  # val_decision() can return final_risk = NA when its rule ladder produces
+  # no category for a pkg (typically remote_only pkgs with a shrunken
+  # viable-metric set). val_pkg() then persists a bundle with decision =
+  # NA. Without a guard, the `!= decisions[1]` comparison in val_build()'s
+  # serial branch evaluates to NA and takes the whole run down. Assert the
+  # NA guard survives.
+  src <- readLines(test_path("..", "..", "R", "val_build.R"))
+  src <- paste(src, collapse = "\n")
+
+  expect_true(grepl("is.na(pkg_meta$decision)", src, fixed = TRUE),
+              info = "val_build.R must NA-guard pkg_meta$decision before !=")
+  expect_true(
+    grepl("has NA decision on its meta bundle", src, fixed = TRUE),
+    info = "NA-decision branch must emit an operator-visible message"
+  )
+})

--- a/tests/testthat/test-val_pkg.R
+++ b/tests/testthat/test-val_pkg.R
@@ -138,3 +138,41 @@ test_that("val_pkg() validates 'val_date' parameter", {
 #   })
 # })
 
+
+test_that("val_pkg NA-decision capture surfaces via source-level markers (#124)", {
+  # val_decision() can return final_risk = NA (typically remote_only /
+  # Bioc pkgs with a thin viable-metric set). val_pkg() must NOT silently
+  # coerce that NA to a tier -- it must (a) keep decision = NA, (b) flip
+  # decision_reason to "Incomplete Assessment", and (c) stash an
+  # `assessment_gaps` list on the meta bundle so val_finalize() and the
+  # summary report can surface it. Standing up the full val_pkg() call
+  # requires a live package build, so pin the invariant at the source
+  # level.
+  src <- readLines(test_path("..", "..", "R", "val_pkg.R"))
+  src <- paste(src, collapse = "\n")
+
+  expect_true(grepl("Incomplete Assessment", src, fixed = TRUE),
+              info = "val_pkg.R must set decision_reason='Incomplete Assessment' when final_risk is NA")
+  expect_true(grepl("is.na(decision$final_risk)", src, fixed = TRUE),
+              info = "val_pkg.R must branch on is.na(decision$final_risk)")
+  expect_true(grepl("assessment_gaps = assessment_gaps", src, fixed = TRUE),
+              info = "meta bundle must carry the assessment_gaps list-col")
+})
+
+test_that("val_finalize preserves assessment_gaps as a list-col (#124)", {
+  # `purrr::list_flatten(bundle)` would explode assessment_gaps across ~5
+  # nested cols. It must be pulled out before flatten (mirroring how
+  # `timings` is handled) and reattached as a single list-col so the
+  # report can read qual_metadata$assessment_gaps[[i]].
+  src <- readLines(test_path("..", "..", "R", "val_finalize.R"))
+  src <- paste(src, collapse = "\n")
+
+  expect_true(
+    grepl("bundle[[\"assessment_gaps\"]] <- NULL", src, fixed = TRUE),
+    info = "val_finalize must strip assessment_gaps before list_flatten()"
+  )
+  expect_true(
+    grepl("x$assessment_gaps <- list(gaps)", src, fixed = TRUE),
+    info = "val_finalize must reattach assessment_gaps as a list-col"
+  )
+})


### PR DESCRIPTION
Closes #124.

## Problem

A recent `val_pipeline()` run crashed at ~1602/1606 with:

```
Error in if (!is_dep_skip && pkg_meta$decision != decisions[1]) { : 
  missing value where TRUE/FALSE needed
```

Root cause: `val_decision()`'s rule ladder can silently return `final_risk = NA` for pkgs whose viable-metric set is too thin to trigger any rule (typically `remote_only` or Bioc pkgs). `val_pkg()` persisted the NA on the meta bundle with `decision_reason = 'Risk Assessment'` (misleading), and `val_build()`'s serial-branch dep-propagation `!=` comparison evaluated to `NA` and took the run down.

14 offenders were identified in the current run: `diffr`, `duckdb`, `fitdistrplus`, `gamlss.dist`, `gss`, `KFAS`, `OpenMx`, `qs2`, `Rfast`, `segmented`, `shinyBS`, `snifter`, `VGAM`, `zellkonverter`. 6 come from `remote_only`, 2 are Bioc, 6 are compiled-heavy CRAN pkgs.

## Approach

Per operator preference: **keep `decision = NA` -- do NOT silently coerce to a tier.** Instead, capture the diagnostic and surface it in the report so operators can triage.

- `R/val_pkg.R`: when `decision$final_risk` is NA, populate a new `assessment_gaps` list on the meta bundle (viable metrics, per-metric `_cat` values, primary/secondary risk categories, synthesized note) and flip `decision_reason` to `'Incomplete Assessment'`.
- `R/val_build.R`: NA-guard the serial-branch `!=` comparison. On NA, log at minimal and skip dep propagation. Parallel branch is already unaffected (it skips the propagation logic entirely). `reject_iteration()` at finalize time already treats NA decisions as non-failing rather than cascading them.
- `R/val_finalize.R`: pull `assessment_gaps` out before `purrr::list_flatten()` (mirroring the `timings` handling) and reattach as a list-col on `qual_metadata`.
- `inst/report/summary/summary_template.qmd`: new **Packages with incomplete assessment** table under Decision Summary + new **Appendix: Incomplete Assessments** section rendering per-pkg gap detail (viable metrics, per-metric categories, cross-joined actual scores from `qual_assessments`).

## Verification

- Targeted: `devtools::test(filter = 'val_pkg')` + `filter = 'val_build'` -- all pass (val_pkg: 8 PASS, val_build: 30 PASS).
- Full: 292 tests, 1 failure (pre-existing `test-bioc-remote-initial-metrics.R`, unrelated).
- Source-level guards pinned via `grepl()` -- see the new test blocks in `test-val_pkg.R` and `test-val_build.R`.

## Files

- `R/val_pkg.R` -- NA capture + `assessment_gaps` on meta bundle.
- `R/val_build.R` -- serial-branch NA guard.
- `R/val_finalize.R` -- `assessment_gaps` list-col preservation.
- `inst/report/summary/summary_template.qmd` -- table + appendix.
- `tests/testthat/test-val_pkg.R`, `tests/testthat/test-val_build.R` -- source-level assertions.
- `dev/dev_find_na_decision.R` -- triage script for hunting NA-decision `_meta.rds` bundles on an existing run.
- `DESCRIPTION`: 0.1.26 -> 0.1.27. `NEWS.md`: new heading + bullet.
