### PR TITLE
Pre-filter already-assessed pkgs from val_build() serial loop (#126)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.27
+Version: 0.1.28
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,19 @@
 
+# val.pipeline 0.1.28
+
+- Pre-filtered already-assessed packages out of `val_build()`'s serial
+  loop, mirroring the `!replace` skip the parallel branch has had
+  since #91. Previously, resuming a mostly-complete run (e.g. 1602 of
+  1606 packages already on disk) meant emitting a `val_msg` line per
+  cached package before the loop even reached the four unassessed
+  ones — clogging the log with thousands of "already assessed" lines.
+  The serial branch now reads `_meta.rds` for each cached package
+  once up front, replays any cached failure (`decision != decisions[1]`,
+  ignoring NAs) into `dont_run` / `failed_pkgs` so subsequent uncached
+  packages still get dep-skipped correctly, and iterates only the
+  filtered `todo` list. The in-loop dep-skip check for newly-assessed
+  failures is unchanged. (#126)
+
 # val.pipeline 0.1.27
 
 - Guarded `val_build()`'s serial-branch dep-propagation check against

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -793,7 +793,66 @@ val_build <- function(
     # the dep-skip branch of `assess_one()`). A plain `for` loop makes
     # the per-iter release explicit and avoids the ~1-3 GB `pkg_bundles`
     # list that used to accumulate on full CRAN+BioC cohorts. See #91.
-    for (i in seq_along(pkgs)) {
+
+    # Pre-filter already-assessed pkgs and replay their failures into
+    # dont_run / failed_pkgs before entering the loop. Same
+    # `!replace` semantic as the parallel branch above (#91). Without
+    # this, a resumed run on a mostly-complete cohort (e.g. 1602 of
+    # 1606 done) would still emit a val_msg line per cached pkg,
+    # clogging the log. The in-loop dep-skip check further down is
+    # preserved untouched -- newly-assessed failures still propagate
+    # to still-pending uncached rev-deps. See #126.
+    todo <- seq_along(pkgs)
+    if (!replace) {
+      pkg_v_all_s   <- paste(pkgs, vers, sep = "_")
+      existing_meta_s <- file.path(assessed,
+                                   paste0(pkg_v_all_s, "_meta.rds"))
+      already_done_s  <- file.exists(existing_meta_s)
+      n_skip_s <- sum(already_done_s)
+      if (n_skip_s > 0L) {
+        # Replay cached failures. Same criterion as the in-loop
+        # branch: decision non-NA and != decisions[1] (typically
+        # "Low"). NA decisions are ignored (val_finalize's
+        # reject_iteration() will handle them). Reads only the two
+        # scalar fields we need out of each cached bundle; the full
+        # bundle is discarded.
+        idx_done <- which(already_done_s)
+        replay_dont <- character(0)
+        replay_fail <- character(0)
+        for (j in idx_done) {
+          bundle_j <- tryCatch(readRDS(existing_meta_s[[j]]),
+                               error = function(e) NULL)
+          if (is.null(bundle_j)) next
+          dec_j <- bundle_j[["decision"]]
+          if (length(dec_j) != 1L || is.na(dec_j)) next
+          if (!identical(dec_j, decisions[1])) {
+            rd_j <- bundle_j[["rev_deps"]]
+            if (length(rd_j) > 0L) {
+              rd_j <- rd_j[!is.na(rd_j)]
+              replay_dont <- c(replay_dont, rd_j)
+            }
+            replay_fail <- c(replay_fail, pkgs[[j]])
+          }
+        }
+        if (length(replay_dont) > 0L) {
+          dont_run <- unique(c(dont_run, replay_dont))
+        }
+        if (length(replay_fail) > 0L) {
+          failed_pkgs <- unique(c(failed_pkgs, replay_fail))
+        }
+        val_msg(paste0("\n--> Skipping ", n_skip_s, " of ",
+                       pkgs_length,
+                       " package(s) already assessed on disk ",
+                       "(`_meta.rds` present under `assessed/`). ",
+                       "Replayed ", length(replay_fail),
+                       " cached failure(s) into dep-skip state. ",
+                       "Set `replace = TRUE` to re-run them.\n"),
+                min_level = "minimal")
+        todo <- which(!already_done_s)
+      }
+    }
+
+    for (i in todo) {
       pkg <- pkgs[[i]]
       ver <- vers[[i]]
       is_dep_skip <- pkg %in% dont_run

--- a/tests/testthat/test-val_build.R
+++ b/tests/testthat/test-val_build.R
@@ -265,3 +265,27 @@ test_that("val_build serial branch guards against NA pkg_meta$decision (#124)", 
     info = "NA-decision branch must emit an operator-visible message"
   )
 })
+
+test_that("val_build serial branch pre-filters cached pkgs + replays failures (#126)", {
+  # Mirror parallel branch's `!replace` skip: when a cached _meta.rds
+  # is on disk for a pkg, the serial loop should not re-issue a
+  # val_msg line per pkg (log spam on resumed runs). Cached failures
+  # must be replayed into dont_run/failed_pkgs so subsequent uncached
+  # pkgs still get dep-skipped correctly.
+  src <- readLines(test_path("..", "..", "R", "val_build.R"))
+  src <- paste(src, collapse = "\n")
+
+  expect_true(
+    grepl("Replayed ", src, fixed = TRUE),
+    info = "serial branch must emit the replay-count message on resume"
+  )
+  expect_true(
+    grepl("replay_dont", src, fixed = TRUE) &&
+      grepl("replay_fail", src, fixed = TRUE),
+    info = "serial branch must accumulate cached-failure replay state"
+  )
+  expect_true(
+    grepl("for (i in todo)", src, fixed = TRUE),
+    info = "serial loop must iterate over `todo` (filtered), not seq_along(pkgs)"
+  )
+})


### PR DESCRIPTION
Closes #126.

## Problem

`val_build()`'s **parallel** branch has skipped cached pkgs on resume (`replace = FALSE`) since #91. The **serial** branch did not — it looped over all pkgs and let `assess_one()`'s cached-fast-path short-circuit each one, emitting a val_msg line per pkg. On a resumed run where 1602 of 1606 pkgs are already done, that's ~1602 lines of log spam before the loop reaches the 4 pkgs that actually need work.

## Fix

Mirror the parallel branch's skip semantic. Before entering the loop, pre-scan cached `_meta.rds` files:

- For each cached pkg whose `decision` is non-NA and != `decisions[1]`, replay its `rev_deps` into `dont_run` and pkg name into `failed_pkgs`. This preserves dep-skip correctness — subsequent uncached pkgs still get skipped if a cached pkg earlier in the list failed.
- NA decisions are ignored (they're handled downstream by `reject_iteration()` in `val_finalize()`).
- The main `for` loop iterates only the filtered `todo` (`which(!already_done)`). In-loop dep-skip check for newly-assessed failures is unchanged.

No new arg — governed by the existing `replace = FALSE` (matches parallel semantic).

## Verification

- `devtools::test(filter = 'val_build')` — all 33 pass.
- Source-level assertions in `test-val_build.R` pin the `for (i in todo)` invariant and the presence of the replay accumulators.

## Files

- `R/val_build.R` — serial pre-filter + replay.
- `tests/testthat/test-val_build.R` — new test.
- `DESCRIPTION` 0.1.27 → 0.1.28. `NEWS.md` new heading + bullet.
