### PR TITLE
Re-fix reject_iteration() convergence loop scope bug in val_finalize() (#128)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.28
+Version: 0.1.29
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,20 @@
 
+# val.pipeline 0.1.29
+
+- Re-fixed the `<<-` scope bug in `val_finalize()`'s
+  `reject_iteration()` convergence loop that was originally patched
+  in `val_build()` via #103. When #101 extracted the loop from
+  `val_build.R` into the new `val_finalize.R`, it carried the
+  pre-existing `<<-` forward verbatim; #103 (in flight against the
+  old `val_build.R` location) never touched the new copy, so the
+  fix was never applied here. `<<-` inside a top-level function
+  writes to the enclosing scope, leaving the local `failed` /
+  `pkgs_df` bindings pinned at their iter-1 values -- turning the
+  fixed-point loop into an infinite loop for any cohort whose
+  iter-1 result differs from the seed. Guarded against a third
+  re-introduction with a source-level test that scans every `.R`
+  file in `R/` for the offending pattern. (#128)
+
 # val.pipeline 0.1.28
 
 - Pre-filtered already-assessed packages out of `val_build()`'s serial

--- a/R/val_finalize.R
+++ b/R/val_finalize.R
@@ -352,10 +352,21 @@ val_finalize <- function(
                  n_after - length(seed_failed), " vs. seed).\n"),
           min_level = "normal")
 
+  # NB: use `<-` (not `<<-`) here. `<<-` inside a top-level function
+  # skips the function's own frame and searches the ENCLOSING scope
+  # (the package namespace, then globalenv) for an existing binding,
+  # leaving the local `failed` / `pkgs_df` bindings unchanged. That
+  # turns the fixed-point loop into an infinite loop the moment the
+  # iter-1 result differs from the seed (i.e. any cohort large enough
+  # that dep propagation actually needs a second pass). Originally
+  # fixed in val_build.R via #103; the bug was reintroduced here when
+  # #101 extracted the loop into val_finalize.R verbatim (including
+  # the pre-existing `<<-`) while #103 was in flight against the old
+  # val_build.R location. See #128 for the regression + guard.
   while (!identical(pkgs_df$pkg[pkgs_df$final_decision != decisions[1]],
                     failed)) {
-    failed <<- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
-    pkgs_df <<- reject_iteration(pkgs_df, dec_reject, deps, decisions, failed)
+    failed <- pkgs_df$pkg[pkgs_df$final_decision != decisions[1]]
+    pkgs_df <- reject_iteration(pkgs_df, dec_reject, deps, decisions, failed)
     iter <- iter + 1L
     n_after <- sum(pkgs_df$final_decision != decisions[1])
     val_msg(paste0("    iter ", iter, ": ", n_after, " pkg(s) above '",

--- a/tests/testthat/test-reject_iteration.R
+++ b/tests/testthat/test-reject_iteration.R
@@ -365,3 +365,25 @@ test_that("the buggy `<<-` variant would have spun forever (regression proof, #1
   }
   expect_equal(run_buggy(), 10L)
 })
+
+test_that("reject_iteration convergence loop uses `<-`, not `<<-`, in any caller (#128)", {
+  # #103 fixed a `<<-` scope bug in val_build.R that turned the
+  # fixed-point loop over reject_iteration() into an infinite loop
+  # for any cohort large enough to need > 1 propagation pass. #101
+  # extracted that same loop into val_finalize.R in flight and copied
+  # the pre-existing bug forward; #103's patch never landed on the
+  # new location. Guard against a third re-introduction by scanning
+  # every .R file in R/ for the specific offending patterns.
+  r_files <- list.files(test_path("..", "..", "R"),
+                        pattern = "\\.R$", full.names = TRUE)
+  hits <- character(0)
+  for (f in r_files) {
+    src <- paste(readLines(f, warn = FALSE), collapse = "\n")
+    if (grepl("failed[[:space:]]*<<-[[:space:]]*pkgs_df", src) ||
+          grepl("pkgs_df[[:space:]]*<<-[[:space:]]*reject_iteration",
+                src)) {
+      hits <- c(hits, basename(f))
+    }
+  }
+  expect_length(hits, 0)
+})


### PR DESCRIPTION
Closes #128.

## TL;DR

An infinite loop in `val_finalize()`'s dep-propagation step, caused by `<<-` in a while loop that #103 was supposed to have fixed a year ago. It got reintroduced when #101 extracted the loop into a new file while #103 was in flight against the old location. Fixed here + added a cross-file source-level guard so it can't come back a fourth time.

## Diagnosis: how did it come back?

The two PRs raced on the same day:

- **#103** (Aug 5, 09:58) fixed the `<<-` bug — but in `R/val_build.R`, where the loop originally lived. Its regression tests targeted `reject_iteration()` itself in isolation, not the caller's while-loop scope.
- **#101** (Aug 5, 07:16, in flight simultaneously) *extracted* the same loop from `R/val_build.R` into a new `R/val_finalize.R`, copying the code **verbatim including the pre-existing `<<-`**. When #103 landed, it patched only the old `val_build.R` location; the surviving copy in `val_finalize.R` was left with the bug.

Latent since #101 merged. Small dev cohorts converge in 1 pass, so the while condition never fires and the bug hid behind #103's targeted tests.

## Fix

- `R/val_finalize.R`: `<<-` → `<-` on both lines. Added an NB comment documenting the extraction / re-fix history so a future refactor can't quietly reintroduce it.
- `tests/testthat/test-reject_iteration.R`: cross-file source-level guard that scans every `.R` file in `R/` for the two offending patterns (`failed <<- pkgs_df`, `pkgs_df <<- reject_iteration`). #103's regression test only exercised `reject_iteration()` in isolation and had no visibility into the caller's scope; this new guard would have caught #101's extraction.
- `DESCRIPTION` 0.1.28 → 0.1.29, `NEWS.md`.

## Verification

- `devtools::test(filter = 'reject_iteration')` — 43 pass.
- `devtools::test(filter = 'val_finalize')` — 23 pass.
- New cross-file guard runs green (would trip red on the pre-fix source).
