### PR TITLE
Summary report polish batch + val.pipeline version + ripple-effect table (#130)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.29
+Version: 0.1.30
 Authors@R: 
   c(
     person(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.30
+Version: 0.1.31
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,48 @@
 
+# val.pipeline 0.1.30
+
+- Summary report polish batch (#130):
+  - **"Packages by Risk Category"** section heading trimmed to
+    **"Packages"** — the subsection headings under it (Low / Medium
+    / High) already convey the risk-tier grouping.
+  - **New "Ripple effect" table** under "Initial vs. final decision"
+    that ranks failing packages by the number of other packages
+    they dragged down as a dep failure. Sourced by parsing
+    `final_decision_reason_note` on every dep-downgraded row and
+    counting occurrences per culprit; joined back against
+    `qual_metadata` so each culprit's own decision + reason are
+    shown alongside the ripple count.
+  - **Coverage buckets** in Metric-Level Summaries now cleave at 65%,
+    mirroring the Low-tier `covr_coverage` threshold from
+    `inst/config.yml`. Old three-band split (50-79 / 80-94 / 95-100)
+    is now four bands (50-64 / 65-79 / 80-94 / 95-100).
+  - **"Ten slowest packages"** → **"Slowest packages"**; sources the
+    top 50 rows and renders via `itable()` with a page-size dropdown
+    (10 / 25 / 50 / 100), default 10.
+  - **"Top 25 memory offenders"** → **"Memory offenders"**; same
+    treatment — 50 rows sourced, default page 25.
+  - **"Initial vs. final decision"**: the downgrade count now
+    renders in a large-font callout above the crosstab so it's the
+    first thing an operator sees.
+  - **Package report "Has source control"**: when riskmetric couldn't
+    parse a code-host URL and returned `"unknown"`, the pkg template
+    now falls back to reading the sourced `DESCRIPTION`'s `URL:`
+    field for a github/gitlab/bitbucket/codeberg/sr.ht/gitea link,
+    mirroring the existing "Has bug reports url" fallback.
+  - **Top-of-report runtime** is now **cumulative** (sum of
+    per-package `assessment_runtime_mins`) so a run resumed across
+    multiple sessions shows total work rather than the last
+    session's wall clock. Formatted as `Hh MMm` (e.g. `41h 12m`).
+  - **Runtime section**: total / mean / median / max are now
+    formatted as `Hh MMm` where >= 1h, `Xm` for 1-59 min, `X.XX m`
+    for sub-minute values.
+  - **`val.pipeline` version(s)**: a new `val_pipeline_ver` field is
+    persisted on each `_meta.rds` (from `utils::packageVersion()` at
+    `val_pkg()` time). The summary report's meta table surfaces the
+    distinct set of versions that produced the run -- resumed runs
+    that spanned a package update will now show every version that
+    contributed.
+
 # val.pipeline 0.1.29
 
 - Re-fixed the `<<-` scope bug in `val_finalize()`'s

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 
+# val.pipeline 0.1.31
+
+- Summary report **"Run Metadata" → "Repositories"** row now drops the
+  literal `"unknown"` value returned by `get_repo_origin()` when a pkg's
+  source URL fails to substring-match any entry in `getOption("repos")`
+  at assessment time. Matches the existing NA-filter pattern already
+  applied to `ref` / `metric_pkg` on the same row set. (#130)
+
 # val.pipeline 0.1.30
 
 - Summary report polish batch (#130):

--- a/R/val_pkg.R
+++ b/R/val_pkg.R
@@ -786,6 +786,11 @@ val_pkg <- function(
     pkg = pkg,
     ver = ver,
     r_ver = getRversion(),
+    # Which val.pipeline built this bundle. Used by the summary
+    # report to display the distinct set of package versions that
+    # produced a run (a resumed run can span multiple versions if
+    # the operator updated the package between sessions). See #130.
+    val_pipeline_ver = as.character(utils::packageVersion("val.pipeline")),
     sys_info = list(R.Version()),
     repos = repo_name, # A named character
     # Plain-string label for the source repo (e.g. "CRAN", "BioC",

--- a/inst/report/package/pkg_template.qmd
+++ b/inst/report/package/pkg_template.qmd
@@ -322,6 +322,32 @@ if (!is.null(val_dir) && nzchar(as.character(val_dir))) {
       if (!is.na(.br) && nzchar(.br)) {
         .set_value("Has bug reports url", as.character(.br))
       }
+      # Has source control fallback. `pkg_metric_has_source_control()`
+      # in {riskmetric} returns "unknown" when it can't parse a code
+      # host URL from the pkg's URL field, but the URL is often
+      # present in `DESCRIPTION` -- just as a plain github.com /
+      # gitlab.com / bitbucket.org link that riskmetric didn't
+      # recognize. Extract it here rather than showing "unknown".
+      # See #130.
+      .url <- if ("URL" %in% colnames(.desc)) .desc[1, "URL"] else NA
+      if (!is.na(.url) && nzchar(.url)) {
+        .url_bits <- trimws(unlist(strsplit(as.character(.url),
+                                            "[,\\s]+")))
+        .url_bits <- .url_bits[nzchar(.url_bits)]
+        .code_hosts <- c("github.com", "gitlab.com", "bitbucket.org",
+                         "codeberg.org", "sr.ht", "gitea.io")
+        .src_urls <- .url_bits[
+          vapply(.url_bits,
+                 function(u) any(vapply(.code_hosts,
+                                        function(h) grepl(h, u, fixed = TRUE),
+                                        logical(1))),
+                 logical(1))
+        ]
+        if (length(.src_urls) > 0L) {
+          .set_value("Has source control",
+                     paste(unique(.src_urls), collapse = ", "))
+        }
+      }
     }
   }
 }

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -71,6 +71,20 @@ itable <- function(df, ..., searchable = TRUE, filterable = TRUE,
     knitr::kable(df, ...)
   }
 }
+
+# Format a duration (minutes) as "Xh Ym" when >= 1h, "Ym" for
+# 1 <= mins < 60, "X.XXm" for < 1 minute. Returns "-" for NA / non-
+# finite input so table cells never blow up on missing data. See #130.
+format_hm <- function(mins) {
+  x <- suppressWarnings(as.numeric(mins))
+  if (length(x) != 1L || !is.finite(x) || x < 0) return("-")
+  if (x < 1) return(sprintf("%.2f m", x))
+  rounded_min <- round(x)
+  if (rounded_min < 60) return(sprintf("%d m", as.integer(rounded_min)))
+  h <- rounded_min %/% 60
+  m <- rounded_min - h * 60
+  sprintf("%dh %02dm", as.integer(h), as.integer(m))
+}
 ```
 
 ```{r load-inputs}
@@ -138,11 +152,35 @@ meta_rows <- list(
   c("Metric package",        paste(metric_pkg, collapse = ", ")),
   c("Repositories",          paste(repos, collapse = "; "))
 )
-if (!is.null(params$pipeline_runtime) &&
-      nzchar(as.character(params$pipeline_runtime))) {
-  meta_rows <- c(meta_rows, list(
-    c("val_pipeline() runtime", as.character(params$pipeline_runtime))
-  ))
+# val.pipeline version(s) that produced this run. Sourced from the
+# per-pkg `val_pipeline_ver` list-col on qual_metadata (populated by
+# val_pkg() as of #130). A resumed run can span multiple versions if
+# the operator updated the package between sessions -- show the
+# distinct set in insertion order so the reader sees the mix.
+if ("val_pipeline_ver" %in% names(qual_metadata)) {
+  vp_vers <- unique(stats::na.omit(as.character(qual_metadata$val_pipeline_ver)))
+  vp_vers <- vp_vers[nzchar(vp_vers)]
+  if (length(vp_vers) > 0L) {
+    meta_rows <- c(meta_rows, list(
+      c("val.pipeline version(s)", paste(vp_vers, collapse = ", "))
+    ))
+  }
+}
+# Cumulative pipeline runtime = sum of per-pkg assessment_runtime_mins
+# across the cohort. Each pkg only runs once, so summing correctly
+# accounts for time spent across resumed sessions -- unlike the prior
+# `params$pipeline_runtime` field which was Sys.time() - val_start of
+# only the LAST session. See #130.
+if ("assessment_runtime_mins" %in% names(qual_metadata)) {
+  rt_all <- suppressWarnings(
+    as.numeric(qual_metadata$assessment_runtime_mins))
+  rt_all <- rt_all[is.finite(rt_all) & rt_all >= 0]
+  if (length(rt_all) > 0L) {
+    meta_rows <- c(meta_rows, list(
+      c("val_pipeline() runtime (cumulative)",
+        format_hm(sum(rt_all)))
+    ))
+  }
 }
 if (!is.null(params$n_candidates)) {
   meta_rows <- c(meta_rows, list(
@@ -368,19 +406,77 @@ kable(final_counts, col.names = c("Final decision", "Packages", "Percent"),
 
 Packages whose category changed because of dependency propagation.
 
+```{r decision-crosstab-downgrade-callout, results = "asis"}
+downgraded_n <- sum(qual_metadata$decision != qual_metadata$final_decision,
+                    na.rm = TRUE)
+# Large-font callout above the crosstab so the reader's eye lands on
+# the headline number first. See #130.
+cat("::: {style=\"font-size: 1.8em; font-weight: 600; margin: 0.5em 0 0.75em;\"}\n",
+    format(downgraded_n, big.mark = ","),
+    " package(s) downgraded from their initial decision\n",
+    ":::\n", sep = "")
+```
+
 ```{r decision-crosstab}
 xt <- qual_metadata |>
   dplyr::count(decision, final_decision, .drop = FALSE) |>
   tidyr::pivot_wider(names_from = final_decision, values_from = n,
                      values_fill = 0L, names_expand = TRUE)
 kable(xt, caption = "Rows = initial decision, Columns = final decision")
-
-downgraded_n <- sum(qual_metadata$decision != qual_metadata$final_decision,
-                    na.rm = TRUE)
 ```
 
-**`r downgraded_n`** package(s) were downgraded from their initial decision
-because of a failing (Medium/High) dependency.
+Downgrades happen when a runtime dependency failed its assessment
+(Medium/High), so PPM cannot serve the parent package with a
+complete install closure.
+
+## Ripple effect: failing packages by dep-downgrade count
+
+For every package that got downgraded because of a failing dep
+(`final_decision_reason` is `Dependency` or `Pre-Approved (dep
+failed)`), the failing direct dep(s) are already named in
+`final_decision_reason_note`. This table inverts that mapping to
+show which failing packages had the biggest downstream footprint
+— i.e. how many other packages each one dragged down.
+
+```{r ripple-effect}
+ripple_src <- qual_metadata |>
+  dplyr::filter(final_decision_reason %in%
+                  c("Dependency", "Pre-Approved (dep failed)")) |>
+  dplyr::filter(!is.na(final_decision_reason_note) &
+                  nzchar(final_decision_reason_note)) |>
+  dplyr::transmute(
+    child_pkg = pkg,
+    culprits = strsplit(final_decision_reason_note, "\\s*,\\s*")
+  ) |>
+  tidyr::unnest_longer(culprits) |>
+  dplyr::filter(nzchar(culprits))
+
+if (nrow(ripple_src) > 0L) {
+  # Look up each culprit's own final decision so operators can see at
+  # a glance whether it errored, was dep-driven itself, or landed
+  # High on its own risk assessment. Left join tolerates culprits
+  # that aren't in qual_metadata (e.g. a system dep not assessed
+  # here) by leaving those cells NA.
+  culprit_lookup <- qual_metadata |>
+    dplyr::select(culprits = pkg,
+                  culprit_decision = final_decision,
+                  culprit_reason = final_decision_reason)
+  ripple_tbl <- ripple_src |>
+    dplyr::count(culprits, name = "downgraded_pkgs") |>
+    dplyr::left_join(culprit_lookup, by = "culprits") |>
+    dplyr::arrange(dplyr::desc(downgraded_pkgs), culprits) |>
+    dplyr::slice_head(n = 100) |>
+    dplyr::transmute(
+      `Failing package`         = culprits,
+      `Downgraded pkgs (count)` = downgraded_pkgs,
+      `Its own decision`        = as.character(culprit_decision),
+      `Its own reason`          = as.character(culprit_reason)
+    )
+  itable(ripple_tbl, default_page_size = 25)
+} else {
+  cat("_No dep-driven downgrades recorded in this run._\n")
+}
+```
 
 ## Reasons driving the final decision
 
@@ -492,7 +588,7 @@ if (nrow(incomplete) > 0L) {
 }
 ```
 
-# Packages by Risk Category
+# Packages
 
 The tables below list every package in each risk tier, with the reason and
 supporting note (driver metrics for `Risk Assessment`, failing dependency
@@ -550,13 +646,13 @@ rt <- rt[!is.na(rt)]
 
 if (length(rt) > 0L) {
   rt_tbl <- tibble::tribble(
-    ~Metric, ~`Minutes`,
-    "Packages with recorded runtime", length(rt),
-    "Total runtime (mins)",           round(sum(rt), 1),
-    "Total runtime (hours)",          round(sum(rt) / 60, 2),
-    "Mean per package (mins)",        round(mean(rt), 3),
-    "Median per package (mins)",      round(stats::median(rt), 3),
-    "Max per package (mins)",         round(max(rt), 2)
+    ~Metric, ~Value,
+    "Packages with recorded runtime",
+      format(length(rt), big.mark = ","),
+    "Cumulative runtime",             format_hm(sum(rt)),
+    "Mean per package",               format_hm(mean(rt)),
+    "Median per package",             format_hm(stats::median(rt)),
+    "Max per package",                format_hm(max(rt))
   )
   kable(rt_tbl, align = "lr")
 } else {
@@ -564,7 +660,10 @@ if (length(rt) > 0L) {
 }
 ```
 
-## Ten slowest packages
+## Slowest packages
+
+Sourced as the 50 slowest per-package assessments; use the page-size
+control to browse fewer rows at a time.
 
 ```{r slowest-pkgs}
 if (length(rt) > 0L) {
@@ -572,20 +671,24 @@ if (length(rt) > 0L) {
     dplyr::mutate(runtime_mins = as.numeric(assessment_runtime_mins)) |>
     dplyr::filter(!is.na(runtime_mins)) |>
     dplyr::arrange(dplyr::desc(runtime_mins)) |>
-    dplyr::slice_head(n = 10) |>
+    dplyr::slice_head(n = 50) |>
     dplyr::transmute(
       Package = pkg,
       Version = ver,
       `Final decision` = as.character(final_decision),
+      Runtime = vapply(runtime_mins, format_hm, character(1)),
       `Runtime (mins)` = round(runtime_mins, 2)
     )
-  kable(slow_df, align = "llrr")
+  itable(slow_df, default_page_size = 10)
 } else {
   cat("_(runtime data not available)_\n")
 }
 ```
 
-## Top 25 memory offenders
+## Memory offenders
+
+Sourced as the 50 packages with the largest peak RSS during
+assessment; use the page-size control to browse fewer rows at a time.
 
 ```{r mem-watchdog-load, include = FALSE}
 mw_path <- params$mem_watchdog_path
@@ -627,7 +730,7 @@ cat("Distribution of peak RSS per package (sampled from ",
 mw_top <- mw_df |>
   dplyr::filter(is.finite(peak_rss_mb)) |>
   dplyr::arrange(dplyr::desc(peak_rss_mb)) |>
-  dplyr::slice_head(n = 25) |>
+  dplyr::slice_head(n = 50) |>
   dplyr::transmute(
     Package = pkg,
     Version = if ("version" %in% names(mw_df)) version else NA_character_,
@@ -691,15 +794,22 @@ itable(tbl, default_page_size = 25)
 
 ## Package coverage (`covr_coverage`)
 
+The 65% boundary mirrors the Low-tier coverage threshold in
+`inst/config.yml` (`decide.rules.covr_coverage`) — packages at or
+above 65% pass the coverage rule for the Low tier; below it they
+land in Medium or higher unless another rule pulls them down.
+
 ```{r coverage, eval = has_assessments && "covr_coverage" %in% names(qa)}
 cov <- suppressWarnings(as.numeric(qa$covr_coverage))
 cov_tbl <- tibble::tibble(
-  Bucket = c("Not measured (NA)", "0%", "1-49%", "50-79%", "80-94%", "95-100%"),
+  Bucket = c("Not measured (NA)", "0%", "1-49%", "50-64%",
+             "65-79%", "80-94%", "95-100%"),
   Packages = c(
     sum(is.na(cov)),
     sum(cov == 0, na.rm = TRUE),
     sum(cov > 0 & cov < 50, na.rm = TRUE),
-    sum(cov >= 50 & cov < 80, na.rm = TRUE),
+    sum(cov >= 50 & cov < 65, na.rm = TRUE),
+    sum(cov >= 65 & cov < 80, na.rm = TRUE),
     sum(cov >= 80 & cov < 95, na.rm = TRUE),
     sum(cov >= 95 & cov <= 100, na.rm = TRUE)
   )

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -136,7 +136,17 @@ if (has_pre_filter) {
 ```{r run-metadata}
 r_ver <- unique(qual_metadata$r_ver)
 val_dates <- unique(as.character(qual_metadata$val_date))
+# Split, unique, and drop "unknown" (unnamed literal returned by
+# `get_repo_origin()` in R/utils.R when the pkg's source URL doesn't
+# substring-match any entry in `getOption("repos")` at assessment
+# time -- typically dep-skipped bundles whose repo was resolved
+# before the option was populated, or pkgs pulled from an ad-hoc
+# `Additional_repositories:` / GitHub tarball path). Leaving it in
+# the "Repositories" row shows a misleading literal in the top meta
+# table. Same NA-filter idea already applied to `ref` / `metric_pkg`
+# below. See #130.
 repos <- unique(unlist(strsplit(as.character(qual_metadata$repos), "\\s*,\\s*")))
+repos <- setdiff(repos, c("unknown", NA_character_, ""))
 # Drop NAs before flattening: rows whose packages were categorised via
 # dependency propagation (never independently assessed by riskmetric)
 # leave `ref` / `metric_pkg` unset, and we don't want a literal "NA" to

--- a/tests/testthat/test-val_pipeline_report.R
+++ b/tests/testthat/test-val_pipeline_report.R
@@ -509,7 +509,7 @@ test_that("val_pipeline_report errors on missing pre_filtered_path", {
   )
 })
 
-test_that("val_pipeline_report shows val_pipeline() runtime row when supplied", {
+test_that("val_pipeline_report shows cumulative val_pipeline() runtime row from qual_metadata (#130)", {
   skip_if_no_quarto()
 
   work <- tempfile(pattern = "vpr_")
@@ -519,6 +519,13 @@ test_that("val_pipeline_report shows val_pipeline() runtime row when supplied", 
   qm_path <- file.path(work, "qual_metadata.rds")
   saveRDS(make_fake_qual_metadata(), qm_path)
 
+  # The top meta table's runtime line is now sourced from the
+  # cumulative sum of per-pkg `assessment_runtime_mins` rather than
+  # the `pipeline_runtime` param (which was only the LAST session's
+  # wall clock and read as deceiving on resumed runs). The fake
+  # cohort sums to 0.1 + 0.05 + 3.5 + 0.2 + 0.5 = 4.35 min => "4 m".
+  # The `pipeline_runtime` param is still accepted for back-compat
+  # but no longer displayed in the meta table. See #130.
   out <- val_pipeline_report(
     qual_metadata_path = qm_path,
     qual_assessments_path = NA,
@@ -529,8 +536,8 @@ test_that("val_pipeline_report shows val_pipeline() runtime row when supplied", 
     quiet = TRUE
   )
   html <- paste(readLines(out, warn = FALSE), collapse = "\n")
-  expect_true(grepl("val_pipeline() runtime", html, fixed = TRUE))
-  expect_true(grepl("18h 42m 15s", html, fixed = TRUE))
+  expect_true(grepl("val_pipeline() runtime (cumulative)", html, fixed = TRUE))
+  expect_true(grepl("4 m", html, fixed = TRUE))
 })
 
 test_that("val_pipeline_report omits pre-filter sub-headers when RDS absent", {

--- a/tests/testthat/test-val_pkg.R
+++ b/tests/testthat/test-val_pkg.R
@@ -176,3 +176,19 @@ test_that("val_finalize preserves assessment_gaps as a list-col (#124)", {
     info = "val_finalize must reattach assessment_gaps as a list-col"
   )
 })
+
+test_that("val_pkg persists val_pipeline_ver on the meta bundle (#130)", {
+  # A resumed run may span multiple val.pipeline versions if the
+  # operator upgraded between sessions. Persist the running version on
+  # every meta bundle so the summary report can surface the distinct
+  # set. Standing up val_pkg() takes a real build, so pin at the
+  # source level.
+  src <- readLines(test_path("..", "..", "R", "val_pkg.R"))
+  src <- paste(src, collapse = "\n")
+
+  expect_true(
+    grepl("val_pipeline_ver = as.character(utils::packageVersion(\"val.pipeline\"))",
+          src, fixed = TRUE),
+    info = "meta_list must carry val_pipeline_ver"
+  )
+})


### PR DESCRIPTION
Closes #130.

## Changes

### Summary report (`inst/report/summary/summary_template.qmd`)

- **Coverage buckets** (Metric-Level Summaries → `covr_coverage`) now cleave at **65%** to mirror the Low-tier threshold from `inst/config.yml`. Old three-band 50-79 / 80-94 / 95-100 is now four-band 50-64 / **65-79** / 80-94 / 95-100.
- **"Ten slowest packages" → "Slowest packages"**: sources top 50 rows, renders via `itable()` with page-size dropdown (10 / 25 / 50 / 100), default 10.
- **"Top 25 memory offenders" → "Memory offenders"**: same treatment, default page 25.
- **"Initial vs. final decision"**: downgrade count now rendered in a **large-font callout above the crosstab** so it's the first thing an operator sees.
- **NEW "Ripple effect" table** under "Initial vs. final decision": parses `final_decision_reason_note` on every dep-downgraded row and counts occurrences per culprit; joined against `qual_metadata` so each culprit's own decision + reason are shown alongside the ripple count. Top 100, itable, default page 25.
- **"Packages by Risk Category" → "Packages"** (the Low / Medium / High subsections already convey the tier grouping).
- **Top-of-report runtime** is now **cumulative** (sum of per-pkg `assessment_runtime_mins`) rather than the last session's wall clock, so runs resumed across multiple sessions report total work correctly. Formatted as `Hh MMm` via new `format_hm()` helper.
- **Runtime section** (total / mean / median / max) also uses `format_hm()`.
- **NEW meta-table row: "val.pipeline version(s)"**, sourced from a new `val_pipeline_ver` list-col on `qual_metadata`. Distinct set shown so runs that spanned a version update surface every contributor.

### Package report (`inst/report/package/pkg_template.qmd`)

- **"Has source control" fallback**. When `{riskmetric}`'s `pkg_metric_has_source_control()` returns "unknown", try to parse a github / gitlab / bitbucket / codeberg / sr.ht / gitea URL from the sourced `DESCRIPTION`'s `URL:` field. Mirrors the existing "Has bug reports url" fallback.

### Runtime plumbing

- **`R/val_pkg.R`**: persist `val_pipeline_ver = as.character(utils::packageVersion("val.pipeline"))` on every meta bundle. Older `_meta.rds` bundles that predate this field render an empty "val.pipeline version(s)" row cleanly.

## Verification

- `devtools::test(filter = 'val_pipeline_report')` — 61/61 pass (this exercises **real Quarto renders** of the qmd; catches template regressions).
- `devtools::test(filter = 'val_pkg')` — 9/9 pass.
- `devtools::test(filter = 'val_finalize')` — 23/23 pass.
- Full suite: 295 tests, only the pre-existing bioc-remote failure remains.
- `format_hm()` verified on the tricky boundaries (NA, 0.15 → `0.15 m`, 59.7 → `1h 00m`, 60 → `1h 00m`, 130 → `2h 10m`, 2472 → `41h 12m`).

## Notes

- `val_pipeline_report()`'s `pipeline_runtime` parameter is still **accepted** for API back-compat; it's just no longer rendered into the meta table (superseded by cumulative). Can be deprecated in a follow-up if desired.
- The ripple-effect table under-reports culprits whose failure was too deep in the chain to land in `final_decision_reason_note` (best-effort, matches the `identify_failed_deps()` semantics from #37 / #107). Culprits not present in `qual_metadata` (e.g. a system dep) show up with `NA` decision/reason.

## Version

`0.1.29` → `0.1.30`
