### PR TITLE
Rehydrate options(repos = opt_repos) inside parallel workers (#132)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.29
+Version: 0.1.32
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,21 @@
 
+# val.pipeline 0.1.32
+
+- **Parallel workers now inherit `options(repos = opt_repos)`** (and
+  `pkgType = "source"` when `ref == "source"`) from the parent
+  session. `future::multisession` boots each worker in a fresh R
+  process that does NOT inherit `options()`, so `get_repo_origin()` ->
+  `getOption("repos")` inside the worker returned R's factory default
+  `c(CRAN = "@CRAN@")`, no substring-match ever hit, and every
+  parallel-assessed pkg was stamped `repos = "unknown"` on its
+  `_meta.rds` bundle. That literal then leaked into the summary
+  report's Run Metadata "Repositories" row and any downstream
+  consumer of `qual_metadata$repos`. Re-apply both options inside the
+  worker's option-priming block, alongside the existing
+  `val.pipeline.verbose` / `val.pipeline.config_path` /
+  `val.pipeline.log_file` / `val.pipeline.log_level` re-hydration.
+  Serial runs (`workers = 1`) were never affected. (#132)
+
 # val.pipeline 0.1.29
 
 - Re-fixed the `<<-` scope bug in `val_finalize()`'s

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 # val.pipeline 0.1.32
 
 - **Parallel workers now inherit `options(repos = opt_repos)`** (and
-  `pkgType = "source"` when `ref == "source"`) from the parent
-  session. `future::multisession` boots each worker in a fresh R
+  `pkgType = "source"` when `ref == "source"`, plus `scipen` from
+  the parent) from the parent session. `future::multisession` boots each worker in a fresh R
   process that does NOT inherit `options()`, so `get_repo_origin()` ->
   `getOption("repos")` inside the worker returned R's factory default
   `c(CRAN = "@CRAN@")`, no substring-match ever hit, and every

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -649,6 +649,12 @@ val_build <- function(
     # runs also match the parent's install behaviour.
     repos_tier    <- opt_repos
     pkgtype_tier  <- if (identical(ref, "source")) "source" else NULL
+    # `scipen` isn't set inside val_build() itself (val_pipeline() /
+    # val_prep_pipeline() set it in the parent session), so it also
+    # fails to cross the multisession boundary. Hoist it to keep
+    # numeric formatting inside worker-emitted strings (versions,
+    # sizes, timing dumps, etc.) matching serial-mode output.
+    scipen_tier   <- getOption("scipen", 0L)
 
     # Pre-filter already-assessed pkgs before dispatch. In parallel
     # mode there's no dep-skip state to update in-loop, so any pkg
@@ -741,6 +747,7 @@ val_build <- function(
               options(repos = repos_tier)
             }
           }
+          options(scipen = scipen_tier)
           assess_one(pkg, ver, pkg_cnt,
                      is_dep_skip = FALSE,
                      failed_snapshot = character(0))

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -638,6 +638,17 @@ val_build <- function(
     # writes so concurrent worker appends interleave cleanly. See #87.
     log_file_tier    <- getOption("val.pipeline.log_file", NULL)
     log_level_tier   <- getOption("val.pipeline.log_level", "normal")
+    # Repo option is likewise NOT inherited across the multisession
+    # boundary. Without this, `get_repo_origin()` -> `getOption("repos")`
+    # inside the worker returns R's default `c(CRAN = "@CRAN@")`, no
+    # substring-match ever hits, and every parallel-assessed pkg gets
+    # `repos = "unknown"` stamped onto its `_meta.rds` bundle (which
+    # then leaks into the summary report's Run Metadata "Repositories"
+    # row and any downstream consumer of `qual_metadata$repos`). See
+    # #132. `pkgType = "source"` piggybacks so parallel source-tier
+    # runs also match the parent's install behaviour.
+    repos_tier    <- opt_repos
+    pkgtype_tier  <- if (identical(ref, "source")) "source" else NULL
 
     # Pre-filter already-assessed pkgs before dispatch. In parallel
     # mode there's no dep-skip state to update in-loop, so any pkg
@@ -722,6 +733,13 @@ val_build <- function(
           if (!is.null(log_file_tier) && nzchar(log_file_tier)) {
             options(val.pipeline.log_file  = log_file_tier,
                     val.pipeline.log_level = log_level_tier)
+          }
+          if (!is.null(repos_tier)) {
+            if (!is.null(pkgtype_tier)) {
+              options(repos = repos_tier, pkgType = pkgtype_tier)
+            } else {
+              options(repos = repos_tier)
+            }
           }
           assess_one(pkg, ver, pkg_cnt,
                      is_dep_skip = FALSE,

--- a/tests/testthat/test-val-build-workers.R
+++ b/tests/testthat/test-val-build-workers.R
@@ -19,3 +19,32 @@ test_that("val_build() rejects non-positive-integer `workers`", {
   expect_error(val_build(workers = NA_integer_), "workers")
   expect_error(val_build(workers = c(1, 2)), "workers")
 })
+
+test_that("parallel workers rehydrate options(repos = opt_repos) (#132)", {
+  # Source-level guard. `future::multisession` boots each worker in a
+  # fresh R session that does NOT inherit `options()`, so the parent's
+  # `options(repos = opt_repos, ...)` set at the top of val_build()
+  # must be explicitly re-applied inside the future_mapply() FUN body.
+  # If someone refactors and drops the re-apply, every parallel-assessed
+  # pkg silently gets `repos = "unknown"` stamped onto its `_meta.rds`
+  # bundle (get_repo_origin() -> getOption("repos") returns R's default
+  # `c(CRAN = "@CRAN@")` with no matching entry). Real end-to-end
+  # verification would require spinning up a multisession cluster and
+  # actually assessing a package, which is prohibitively expensive
+  # here; a source-level presence check catches the regression class.
+  src_path <- system.file("R", "val_build.R", package = "val.pipeline",
+                          mustWork = FALSE)
+  if (!nzchar(src_path) || !file.exists(src_path)) {
+    src_path <- testthat::test_path("..", "..", "R", "val_build.R")
+  }
+  skip_if_not(file.exists(src_path), "val_build.R source not available")
+  src <- paste(readLines(src_path, warn = FALSE), collapse = "\n")
+
+  # Parent hoists opt_repos into a tier variable alongside the other
+  # option tiers already re-hydrated across the worker boundary.
+  expect_match(src, "repos_tier\\s*<-\\s*opt_repos", perl = TRUE)
+
+  # Worker body re-applies options(repos = repos_tier). Allow either
+  # the `pkgType`-included or bare form.
+  expect_match(src, "options\\(repos\\s*=\\s*repos_tier", perl = TRUE)
+})


### PR DESCRIPTION
Closes #132.

## Why

The summary report's Run Metadata **Repositories** row listed `unknown` on every parallel run, and every `_meta.rds` bundle produced by `workers > 1` had `$repos == "unknown"`. Serial runs were unaffected.

## Root cause

`R/val_build.R` L621 launches `future::plan(future::multisession, workers = workers)`. The comment right below already warns:

> `future::multisession` boots each worker in a fresh R session that does NOT inherit the parent's `options()`.

The worker body then re-applies `val.pipeline.verbose` / `val.pipeline.config_path` / `val.pipeline.log_file` / `val.pipeline.log_level` — but never re-applies the parent's `options(repos = opt_repos, pkgType = ...)`. Inside the worker, `getOption("repos")` returns R's factory default `c(CRAN = "@CRAN@")`. In `get_repo_origin()` (`R/utils.R:80-84`):

```r
matched <- curr_repos[stringr::str_detect(repo_src, curr_repos)]
if (length(matched) == 0) return("unknown")
```

`str_detect("<real PPM URL>", "@CRAN@")` never matches → `return("unknown")`. That value is then stashed on `meta$repos` in every code path: normal assessment (`R/val_pkg.R:97`), dep-skip pre-skip branch (`R/val_build.R:530`), and error-catch branch (`R/val_build.R:437`).

## Fix

Capture `opt_repos` (and `pkgType` when `ref == "source"`) into hoist variables alongside the existing option tiers, then re-apply inside the `future_mapply()` FUN body. One-liner class of change, contained to the parallel branch.

## Verification

- **Targeted**: `devtools::test(filter = "val-build-workers")` → 10/10 pass (includes new source-level regression guard).
- **Adjacent**: `devtools::test(filter = "val_build")` → 33/33 pass.
- Real end-to-end parallel assessment is prohibitively expensive to unit-test; regression guard is a source-level presence check for both the tier hoist and the worker-side re-apply.

## Scope

- No back-heal of existing `_meta.rds` bundles — #131's display filter handles the cosmetic leak on old runs.
- Serial `workers = 1` path untouched.
- Version bump 0.1.29 → 0.1.32 (leaves headroom in case #131 merges after; happy to renumber on request).