### PR TITLE
Fix typst PDF render: font-weight: 600 -> bold in downgrade callout (#134)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.32
+Version: 0.1.33
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,20 @@
 
+# val.pipeline 0.1.33
+
+- **Summary report PDF renders again.** The `decision-crosstab-
+  downgrade-callout` chunk added in #131 wrote CSS
+  `font-weight: 600` on the callout span. Pandoc translates that
+  numeric weight into typst `weight: "600"` (a string) which
+  typst rejects — it accepts integers 100-900 or the named weights
+  `"thin"` / `"regular"` / `"semibold"` / `"bold"` / etc. HTML
+  renders unaffected; only the typst PDF backend was broken.
+  Switch to `font-weight: bold`, which Pandoc maps cleanly to
+  `weight: "bold"` in typst and renders essentially the same in
+  HTML. Adds a `format = "pdf"` regression test to
+  `test-val_pipeline_report.R` since every existing test in that
+  file explicitly requests `format = "html"` and never exercised
+  the typst path. (#134)
+
 # val.pipeline 0.1.32
 
 - **Parallel workers now inherit `options(repos = opt_repos)`** (and

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -421,7 +421,7 @@ downgraded_n <- sum(qual_metadata$decision != qual_metadata$final_decision,
                     na.rm = TRUE)
 # Large-font callout above the crosstab so the reader's eye lands on
 # the headline number first. See #130.
-cat("::: {style=\"font-size: 1.8em; font-weight: 600; margin: 0.5em 0 0.75em;\"}\n",
+cat("::: {style=\"font-size: 1.8em; font-weight: bold; margin: 0.5em 0 0.75em;\"}\n",
     format(downgraded_n, big.mark = ","),
     " package(s) downgraded from their initial decision\n",
     ":::\n", sep = "")

--- a/tests/testthat/test-val_pipeline_report.R
+++ b/tests/testthat/test-val_pipeline_report.R
@@ -694,3 +694,50 @@ test_that("val_pipeline_report disables renv autoloader for the quarto subproces
   expect_identical(Sys.getenv("RENV_CONFIG_AUTOLOADER_ENABLED", unset = NA),
                    NA_character_)
 })
+
+test_that("val_pipeline_report renders PDF via typst without weight errors (#134)", {
+  # Every other test in this file passes `format = "html"` and never
+  # exercises the typst PDF backend. #131's downgrade-callout used
+  # numeric CSS `font-weight: 600`, which Pandoc translates into
+  # typst `weight: "600"` (a stringified integer). Typst accepts
+  # integers 100-900 OR named weights ("thin" / ... / "semibold" /
+  # "bold" / ...) but not a string containing digits, so PDF
+  # renders blew up mid-typst-compile while HTML renders were fine.
+  # This test locks the fix in: any future numeric-weight regression
+  # would fail the typst compile the same way.
+  skip_if_no_quarto()
+
+  work <- tempfile(pattern = "vpr_pdf_")
+  dir.create(work)
+  on.exit(unlink(work, recursive = TRUE), add = TRUE)
+
+  qm_path <- file.path(work, "qual_metadata.rds")
+  saveRDS(make_fake_qual_metadata(), qm_path)
+
+  out <- tryCatch(
+    val_pipeline_report(
+      qual_metadata_path    = qm_path,
+      qual_assessments_path = NA,
+      format                = "pdf",
+      quiet                 = TRUE
+    ),
+    error = function(e) e
+  )
+  # Some environments ship Quarto without the bundled typst binary
+  # (or without a working local typst install). If that's the case
+  # the render fails with a typst-not-found message rather than a
+  # weight-validation error -- skip cleanly instead of failing.
+  if (inherits(out, "error")) {
+    msg <- conditionMessage(out)
+    if (grepl("typst", msg, ignore.case = TRUE) &&
+        grepl("not found|no such file|command not found|installed",
+              msg, ignore.case = TRUE)) {
+      skip("typst backend not available in this environment")
+    }
+    stop(out)
+  }
+
+  expect_length(out, 1L)
+  expect_true(file.exists(out))
+  expect_match(out, "\\.pdf$")
+})


### PR DESCRIPTION
Closes #134.

## What was broken

`val_pipeline_report(format = "pdf")` (default is `c("html", "pdf")`) failed at the typst compile step with:

```
error: expected integer, "thin", ..., "semibold", "bold", ...
  387 | #set text(size: 1.8em , weight: "600");
```

HTML rendered fine.

## Root cause

The `decision-crosstab-downgrade-callout` chunk in `inst/report/summary/summary_template.qmd` (added in #131) emits inline CSS:

```r
cat("::: {style=\"font-size: 1.8em; font-weight: 600; margin: ...\"}\n", ...)
```

Pandoc translates CSS `font-weight: 600` into typst `weight: \"600\"` — a **string** containing digits. Typst's `text()` accepts an integer 100-900 OR a named weight (`\"thin\"` ... `\"black\"`) but not a stringified integer.

## Why tests missed it

Every test in `test-val_pipeline_report.R` explicitly passes `format = \"html\"`. The typst backend was never exercised in CI.

## Fix

- **Template**: swap `font-weight: 600` → `font-weight: bold`. Pandoc maps CSS bold cleanly to typst `weight: \"bold\"`. Visual delta in HTML is imperceptible on a large-font callout.
- **Regression test**: added a `format = \"pdf\"` render at the end of `test-val_pipeline_report.R` that goes end-to-end through the typst backend and asserts a .pdf file lands on disk. Skips cleanly if the typst backend isn't installed in the environment.

## Verification

- `devtools::test(filter=\"val_pipeline_report\")` → **64/64 pass, 0 skips** in ~110s. The typst backend was available on this dev host, so the new PDF test actually rendered end-to-end — real coverage, not a skipped stub.

## Scope

Version bump 0.1.32 → 0.1.33. Contained, no schema changes.