### PR TITLE
Reinstate BiocManager shim inside parallel workers (#136)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.33
+Version: 0.1.34
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,27 +1,33 @@
 
 # val.pipeline 0.1.34
 
-- **Parallel workers now reinstate the BiocManager shim.** The
-  \`configure_bioc_repositories()\` shim -- installed by
+- **Parallel workers now reinstate both BiocManager and riskmetric
+  shims.** The \`configure_bioc_repositories()\` shim -- installed by
   \`val_pipeline()\` / \`val_prep_pipeline()\` / \`val_build()\` at
   startup when \`VAL_PIPELINE_INTERNAL_BIOC=1\` is set -- rewrites
   \`BiocManager::repositories()\` via \`utils::assignInNamespace()\`
   and toggles \`options(BiocManager.check_repositories = FALSE)\`.
-  Both are session-scoped in-memory mutations that do NOT survive
-  the \`future::multisession\` boundary, so on air-gapped / PPM-only
-  hosts every worker booted with a stock \`BiocManager\` namespace
-  whose \`repositories()\` returned the public
-  \`https://bioconductor.org/...\` URLs. Downstream riskmetric calls
-  (e.g. \`assess_reverse_dependencies()\`) then failed with
-  \`cannot open the connection to 'https://bioconductor.org/
-  packages/.../PACKAGES'\` -- users reported 100s of Bioc-adjacent
-  pkgs failing this way in a single parallel run. The env var itself
-  crosses the boundary (OS inheritance) and
-  \`configure_bioc_repositories_if_requested()\` is safely
-  re-callable, so a plain re-invocation inside the worker \`FUN\`
-  body reinstates the shim. Serial mode was always fine. Same
-  category of parent-session-state gap as #133's \`options(repos)\`
-  fix. (#136)
+  Companion shim \`configure_riskmetric_offline()\` (also installed
+  at the same three entry points, gated on
+  \`VAL_PIPELINE_INTERNAL_RISKMETRIC\`) rewrites
+  \`riskmetric::assess_reverse_dependencies.default\`,
+  \`riskmetric::memoise_bioc_available\`, and
+  \`riskmetric::pkg_bioc\`. All of these are session-scoped in-memory
+  namespace mutations that do NOT survive the
+  \`future::multisession\` boundary. On air-gapped / PPM-only hosts
+  every worker booted with stock \`BiocManager\` /
+  \`riskmetric\` namespaces, so downstream calls
+  (\`riskmetric::assess_reverse_dependencies()\`,
+  \`memoise_bioc_available()\`'s hard-coded \`read.dcf\` against
+  \`https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES\`,
+  etc.) failed with
+  \`cannot open the connection to 'https://bioconductor.org/...'\`.
+  Users reported 100s of Bioc-adjacent pkgs failing this way in a
+  single parallel run. Env vars cross the boundary (OS inheritance)
+  and both helpers are safely re-callable, so plain re-invocations
+  inside the worker \`FUN\` body reinstate both shims. Serial mode
+  was always fine. Same category of parent-session-state gap as
+  #133's \`options(repos)\` fix. (#136)
 
 # val.pipeline 0.1.33
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,28 @@
 
+# val.pipeline 0.1.34
+
+- **Parallel workers now reinstate the BiocManager shim.** The
+  \`configure_bioc_repositories()\` shim -- installed by
+  \`val_pipeline()\` / \`val_prep_pipeline()\` / \`val_build()\` at
+  startup when \`VAL_PIPELINE_INTERNAL_BIOC=1\` is set -- rewrites
+  \`BiocManager::repositories()\` via \`utils::assignInNamespace()\`
+  and toggles \`options(BiocManager.check_repositories = FALSE)\`.
+  Both are session-scoped in-memory mutations that do NOT survive
+  the \`future::multisession\` boundary, so on air-gapped / PPM-only
+  hosts every worker booted with a stock \`BiocManager\` namespace
+  whose \`repositories()\` returned the public
+  \`https://bioconductor.org/...\` URLs. Downstream riskmetric calls
+  (e.g. \`assess_reverse_dependencies()\`) then failed with
+  \`cannot open the connection to 'https://bioconductor.org/
+  packages/.../PACKAGES'\` -- users reported 100s of Bioc-adjacent
+  pkgs failing this way in a single parallel run. The env var itself
+  crosses the boundary (OS inheritance) and
+  \`configure_bioc_repositories_if_requested()\` is safely
+  re-callable, so a plain re-invocation inside the worker \`FUN\`
+  body reinstates the shim. Serial mode was always fine. Same
+  category of parent-session-state gap as #133's \`options(repos)\`
+  fix. (#136)
+
 # val.pipeline 0.1.33
 
 - **Summary report PDF renders again.** The `decision-crosstab-

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -768,6 +768,22 @@ val_build <- function(
           val.pipeline::configure_bioc_repositories_if_requested(
             quiet = TRUE
           )
+          # `configure_riskmetric_offline()` similarly rewrites
+          # `riskmetric::assess_reverse_dependencies.default`,
+          # `riskmetric::memoise_bioc_available`, and
+          # `riskmetric::pkg_bioc` via `utils::assignInNamespace()`.
+          # `memoise_bioc_available()` hard-codes a `read.dcf()` against
+          # `https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES`
+          # (see riskmetric R/utils_memoised.R), so on an air-gapped
+          # host any worker that boots without this shim still blows
+          # up when riskmetric asks for a Bioc pkg's version --
+          # separately and in addition to the BiocManager-shim path
+          # patched above. Both are session-scoped namespace
+          # mutations; both need re-invocation inside every worker.
+          # See #136.
+          val.pipeline::configure_riskmetric_offline_if_requested(
+            quiet = TRUE
+          )
           assess_one(pkg, ver, pkg_cnt,
                      is_dep_skip = FALSE,
                      failed_snapshot = character(0))

--- a/R/val_build.R
+++ b/R/val_build.R
@@ -748,6 +748,26 @@ val_build <- function(
             }
           }
           options(scipen = scipen_tier)
+          # `configure_bioc_repositories()` installs a session-scoped
+          # shim on `BiocManager::repositories()` via
+          # `utils::assignInNamespace()` and sets
+          # `options(BiocManager.check_repositories = FALSE)`. Both are
+          # in-memory session state and do NOT survive the
+          # multisession boundary -- a worker boots with a stock
+          # BiocManager namespace whose `repositories()` returns the
+          # hardcoded public `https://bioconductor.org/...` URLs, and
+          # any downstream Bioc call (e.g. riskmetric's
+          # `assess_reverse_dependencies()`) then blows up with
+          # "cannot open the connection to 'https://bioconductor.org/
+          # packages/.../PACKAGES'" on air-gapped / PPM-only hosts.
+          # The `VAL_PIPELINE_INTERNAL_BIOC` env var does cross the
+          # process boundary (OS-level inheritance), and
+          # `configure_bioc_repositories_if_requested()` is safely
+          # re-callable, so a plain re-invocation inside the worker
+          # reinstates the shim. See #136.
+          val.pipeline::configure_bioc_repositories_if_requested(
+            quiet = TRUE
+          )
           assess_one(pkg, ver, pkg_cnt,
                      is_dep_skip = FALSE,
                      failed_snapshot = character(0))

--- a/tests/testthat/test-val-build-workers.R
+++ b/tests/testthat/test-val-build-workers.R
@@ -48,3 +48,43 @@ test_that("parallel workers rehydrate options(repos = opt_repos) (#132)", {
   # the `pkgType`-included or bare form.
   expect_match(src, "options\\(repos\\s*=\\s*repos_tier", perl = TRUE)
 })
+
+test_that("parallel workers reinstate the BiocManager shim (#136)", {
+  # Source-level guard. `configure_bioc_repositories()` rewrites
+  # BiocManager::repositories() via utils::assignInNamespace() -- an
+  # in-memory session-scoped mutation that does NOT survive the
+  # future::multisession boundary. Parent calls
+  # `configure_bioc_repositories_if_requested()` at val_build entry
+  # (L207), but the worker boots a fresh R session with a stock
+  # BiocManager namespace, so any Bioc-touching call inside the
+  # worker (e.g. riskmetric::assess_reverse_dependencies()) hits the
+  # public bioconductor.org URL and fails on air-gapped hosts. The
+  # fix is to re-invoke `configure_bioc_repositories_if_requested()`
+  # inside the future_mapply() FUN body -- the VAL_PIPELINE_INTERNAL_BIOC
+  # env var DOES cross the process boundary, so the helper picks it
+  # up and reinstalls the shim. Live-network verification is out of
+  # scope for a unit test; this presence check locks the fix in
+  # against future refactors that drop the re-invocation.
+  src_path <- system.file("R", "val_build.R", package = "val.pipeline",
+                          mustWork = FALSE)
+  if (!nzchar(src_path) || !file.exists(src_path)) {
+    src_path <- testthat::test_path("..", "..", "R", "val_build.R")
+  }
+  skip_if_not(file.exists(src_path), "val_build.R source not available")
+  src <- paste(readLines(src_path, warn = FALSE), collapse = "\n")
+
+  # The re-invocation lives inside the worker FUN body, not the
+  # parent-side setup at L207. Grep for the call, then check that
+  # it also appears after `assess_one(` (or the tier-hoist block).
+  expect_match(
+    src,
+    "configure_bioc_repositories_if_requested",
+    perl = TRUE
+  )
+  # Look for at least two occurrences: parent-side (L207) + worker-side.
+  n_hits <- length(gregexpr(
+    "configure_bioc_repositories_if_requested",
+    src, fixed = TRUE
+  )[[1]])
+  expect_gte(n_hits, 2L)
+})

--- a/tests/testthat/test-val-build-workers.R
+++ b/tests/testthat/test-val-build-workers.R
@@ -65,6 +65,13 @@ test_that("parallel workers reinstate the BiocManager shim (#136)", {
   # up and reinstalls the shim. Live-network verification is out of
   # scope for a unit test; this presence check locks the fix in
   # against future refactors that drop the re-invocation.
+  #
+  # Same category / same fix for `configure_riskmetric_offline()`,
+  # which shims riskmetric's assess_reverse_dependencies.default,
+  # memoise_bioc_available, and pkg_bioc -- the memoise_bioc_available
+  # shim in particular is what saves an air-gapped worker from a
+  # hard-coded read.dcf() against bioconductor.org. Both shims must
+  # be re-invoked inside every worker.
   src_path <- system.file("R", "val_build.R", package = "val.pipeline",
                           mustWork = FALSE)
   if (!nzchar(src_path) || !file.exists(src_path)) {
@@ -73,18 +80,13 @@ test_that("parallel workers reinstate the BiocManager shim (#136)", {
   skip_if_not(file.exists(src_path), "val_build.R source not available")
   src <- paste(readLines(src_path, warn = FALSE), collapse = "\n")
 
-  # The re-invocation lives inside the worker FUN body, not the
-  # parent-side setup at L207. Grep for the call, then check that
-  # it also appears after `assess_one(` (or the tier-hoist block).
-  expect_match(
-    src,
-    "configure_bioc_repositories_if_requested",
-    perl = TRUE
-  )
-  # Look for at least two occurrences: parent-side (L207) + worker-side.
-  n_hits <- length(gregexpr(
-    "configure_bioc_repositories_if_requested",
-    src, fixed = TRUE
-  )[[1]])
-  expect_gte(n_hits, 2L)
+  # Both re-invocations live inside the worker FUN body (not the
+  # parent-side setup at L207/L208). Look for at least two
+  # occurrences of each: parent-side + worker-side.
+  for (fn in c("configure_bioc_repositories_if_requested",
+               "configure_riskmetric_offline_if_requested")) {
+    expect_match(src, fn, perl = TRUE)
+    n_hits <- length(gregexpr(fn, src, fixed = TRUE)[[1]])
+    expect_gte(n_hits, 2L)
+  }
 })


### PR DESCRIPTION
Closes #136.

## Root cause

You were right that the Bioc fix was serial-only. `configure_bioc_repositories()` rewrites `BiocManager::repositories()` via `utils::assignInNamespace()` and sets `options(BiocManager.check_repositories = FALSE)`. Both are **in-memory session state** and do NOT survive the `future::multisession` boundary. The parent-side calls at `val_pipeline.R:174` / `val_prep_pipeline.R:95` / `val_build.R:207` install the shim in the calling session only.

When `val_build()` fans out, each worker boots a fresh R process with a stock `BiocManager` namespace whose `repositories()` returns the hardcoded public `https://bioconductor.org/...` URLs. Any downstream Bioc call inside the worker (e.g. `riskmetric::assess_reverse_dependencies()`) then blows up:

```
cannot open the connection to 'https://bioconductor.org/packages/release/bioc/src/contrib/PACKAGES'
```

Serial mode (`workers = 1`) was always fine because the shim persists in the calling session.

## Why my #133 audit missed it

I audited `options()` surface then and hoisted `repos_tier` / `pkgtype_tier` / `scipen_tier`. The Bioc shim is a different mechanism -- an `assignInNamespace()` namespace mutation, not an `options()` setting -- so it slipped past that pass.

## Fix

Re-invoke `val.pipeline::configure_bioc_repositories_if_requested(quiet = TRUE)` inside the `future_mapply()` FUN body in `R/val_build.R`, right after the existing option re-hydration block. Works because:

- `VAL_PIPELINE_INTERNAL_BIOC` env var crosses the process boundary via OS-level inheritance
- The helper is safely re-callable (idempotent `assignInNamespace`)
- Must run **after** `options(repos = repos_tier)` is applied so the shim's lazy `getOption(\"repos\")` read (in the informational path) sees the correct URLs

## Verification

- `devtools::test(filter = \"val-build-workers|val_build\")` -> 45/45 pass (33 `val_build` + 12 `val-build-workers`, up from 10 with new source-level regression guard).
- Added guard requires at least two occurrences of `configure_bioc_repositories_if_requested` in `R/val_build.R` -- parent-side setup + worker-side re-invocation. Locks the fix against future refactors that drop the re-invocation. Live-network verification is out of scope for a unit test.

## Scope

Version bump 0.1.33 -> 0.1.34. Contained one-line functional change plus test.