### PR TITLE
Report polish: elapsed runtime, riskscore/riskmetric versions, colored risk cards, downgrade card, RSS definition (#138)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.34
+Version: 0.1.35
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,37 @@
 
+# val.pipeline 0.1.35
+
+- Summary report polish batch (#138):
+  - **Run Metadata**: new `Elapsed time` row alongside the existing
+    cumulative-runtime row. Sourced by parsing the first
+    `=== val_build() @ <timestamp> ===` banner in
+    `<val_dir>/val_pipeline.log` (written by `init_val_log()` at
+    `val_build()` entry) and comparing to render time. Complements
+    the cumulative row: for resumed multi-session runs, elapsed
+    includes the calendar gap between sessions.
+  - **Run Metadata**: `Metric package` row now includes the installed
+    version, e.g. `riskmetric 0.2.5`. Sourced from
+    `utils::packageVersion()` at render time.
+  - **Run Metadata**: new `Pre-filter method` row inserted before
+    `Metric package`, showing `riskscore <version>`. Omitted when
+    riskscore isn't installed.
+  - **Downgrade callout** in "Initial vs. final decision" upgraded
+    from a bare bold-text block to a tinted bordered infographic
+    card (pastel-orange) so it separates visibly from the section
+    headers instead of blending in.
+  - **Risk-level infographic cards**: new colored card strip
+    (pastel green / yellow / red for Low / Medium / High) rendered
+    under both `Final decision counts` (replacing the previous
+    table entirely) and the `Packages` header. Each card shows
+    count + percent in large font. Palette generalizes to future
+    N-band schemes via a green->yellow->red gradient interpolated
+    with `grDevices::colorRampPalette()`.
+  - **Memory offenders**: spell out **RSS** = Resident Set Size on
+    first use.
+  - Passes new `log_file_path` param to the summary template so
+    the elapsed-runtime calculation can find the log; populated
+    automatically from `<input_dir>/val_pipeline.log` when present.
+
 # val.pipeline 0.1.34
 
 - **Parallel workers now reinstate both BiocManager and riskmetric

--- a/R/val_pipeline_report.R
+++ b/R/val_pipeline_report.R
@@ -168,6 +168,19 @@ val_pipeline_report <- function(
     NULL
   }
 
+  # Sibling val_pipeline.log, if any. The template parses its first
+  # `=== val_build() @ <timestamp> ===` header line to compute the
+  # elapsed wall-clock time from initial run kickoff to report render
+  # -- useful for reporting real-world "how long did this run take",
+  # which for a resumed multi-session run differs from cumulative
+  # per-pkg assessment time. See #138.
+  log_candidate <- file.path(input_dir, "val_pipeline.log")
+  log_file_path <- if (file.exists(log_candidate)) {
+    normalizePath(log_candidate, winslash = "/", mustWork = TRUE)
+  } else {
+    NULL
+  }
+
   # Sibling config.yml, if any
   config_candidate <- file.path(input_dir, "config.yml")
   config_path <- if (file.exists(config_candidate)) {
@@ -328,7 +341,8 @@ val_pipeline_report <- function(
     n_candidates = n_candidates_val,
     pre_filtered_path = pf_path,
     pipeline_runtime = runtime_str,
-    mem_watchdog_path = mem_watchdog_path
+    mem_watchdog_path = mem_watchdog_path,
+    log_file_path = log_file_path
   )
 
   # Quarto spawns a child Rscript for the render. If that child sees an

--- a/inst/report/summary/summary_template.qmd
+++ b/inst/report/summary/summary_template.qmd
@@ -15,6 +15,7 @@ params:
   pre_filtered_path: NULL
   pipeline_runtime: NULL
   mem_watchdog_path: NULL
+  log_file_path: NULL
 format:
   html:
     toc: true
@@ -85,6 +86,92 @@ format_hm <- function(mins) {
   m <- rounded_min - h * 60
   sprintf("%dh %02dm", as.integer(h), as.integer(m))
 }
+
+# Elapsed wall-clock runtime from initial run kickoff -> report render.
+# Sourced by grepping val_pipeline.log for its first
+#   `=== val_build() @ <timestamp> ===`
+# banner (see `init_val_log()` header format in R/val_build.R). This
+# is different from the cumulative per-pkg assessment sum: for a
+# resumed multi-session run, the elapsed time counts the calendar
+# gap between sessions where nothing was actively assessed, whereas
+# the cumulative value doesn't. Both are useful, so both are shown.
+# Returns NA_real_ (minutes) when the log is unavailable / unparseable.
+# See #138.
+elapsed_minutes_from_log <- function(log_path) {
+  if (is.null(log_path) || !nzchar(log_path) || !file.exists(log_path)) {
+    return(NA_real_)
+  }
+  lines <- tryCatch(readLines(log_path, warn = FALSE),
+                    error = function(e) character(0))
+  if (length(lines) == 0L) return(NA_real_)
+  # Header format from R/val_build.R:341-343:
+  #   === val_build() @ 2026-08-19 09:38:41 EDT (R 4.5.2, ...) ===
+  m <- regmatches(
+    lines,
+    regexpr("=== val_build\\(\\) @ ([0-9]{4}-[0-9]{2}-[0-9]{2} [0-9:]+ [A-Z]+)",
+            lines, perl = TRUE)
+  )
+  # regexpr returns "" for non-matches; drop them
+  m <- m[nzchar(m)]
+  if (length(m) == 0L) return(NA_real_)
+  first <- sub("=== val_build\\(\\) @ ", "", m[1])
+  # Split off the trailing tz abbreviation; strptime handles the rest.
+  parts <- strsplit(first, " ")[[1]]
+  tz <- parts[length(parts)]
+  stamp_str <- paste(parts[-length(parts)], collapse = " ")
+  t0 <- suppressWarnings(
+    as.POSIXct(stamp_str, format = "%Y-%m-%d %H:%M:%S", tz = tz)
+  )
+  if (is.na(t0)) return(NA_real_)
+  as.numeric(difftime(Sys.time(), t0, units = "mins"))
+}
+
+# Pastel green -> yellow -> red gradient for N ordered risk tiers.
+# 3 tiers (Low / Medium / High): the anchor triplet directly.
+# N > 3: interpolate via colorRampPalette so the pattern generalizes
+# to future 5-band schemes without changing the caller. See #138.
+risk_palette <- function(n) {
+  stopifnot(is.numeric(n), n >= 1L)
+  anchors <- c("#B7E4C7", "#FFF3B0", "#F8B4B4")  # pastel green/yellow/red
+  if (n == 1L) return(anchors[1])
+  if (n == 2L) return(anchors[c(1, 3)])
+  if (n == 3L) return(anchors)
+  grDevices::colorRampPalette(anchors)(n)
+}
+
+# Render a horizontal strip of infographic cards, one per risk tier.
+# `counts` is a named integer vector where names are the tier labels
+# in ranked order (low-risk first). Emits raw HTML via cat(..., sep="");
+# caller must set `results = "asis"` on the chunk. In typst/PDF the
+# same HTML lands via pandoc's html->typst conversion -- inline
+# background-color / border on a div is safe (unlike numeric CSS
+# font-weight -- see #134). Card count line uses `font-weight: bold`
+# for the same reason. See #138.
+render_risk_cards <- function(counts, total = sum(counts)) {
+  if (length(counts) == 0L) return(invisible(NULL))
+  cols <- risk_palette(length(counts))
+  pct <- if (total > 0L) 100 * counts / total else rep(0, length(counts))
+  cat("::: {style=\"display: flex; flex-wrap: wrap; gap: 0.75em; ",
+      "margin: 0.75em 0 1.25em;\"}\n", sep = "")
+  for (i in seq_along(counts)) {
+    cat(
+      "::: {style=\"flex: 1 1 12em; min-width: 10em; ",
+      "background-color: ", cols[i], "; ",
+      "border: 1px solid rgba(0,0,0,0.15); border-radius: 8px; ",
+      "padding: 0.75em 1em; text-align: center;\"}\n",
+      "**", names(counts)[i], "**\n\n",
+      "[",
+      format(as.integer(counts[i]), big.mark = ","),
+      "]{style=\"font-size: 2.2em; font-weight: bold; ",
+      "display: block; line-height: 1.1;\"}\n",
+      "[", sprintf("%.1f%%", pct[i]),
+      "]{style=\"font-size: 1em;\"}\n",
+      ":::\n",
+      sep = ""
+    )
+  }
+  cat(":::\n", sep = "")
+}
 ```
 
 ```{r load-inputs}
@@ -152,16 +239,42 @@ repos <- setdiff(repos, c("unknown", NA_character_, ""))
 # leave `ref` / `metric_pkg` unset, and we don't want a literal "NA" to
 # leak into the human-readable metadata table.
 metric_pkg <- setdiff(unique(qual_metadata$metric_pkg), NA)
+# Append the installed version to each metric pkg name so the reader
+# knows which release produced the assessments. Multiple metric pkgs
+# on one row set is unusual but supported. See #138.
+metric_pkg_verstr <- vapply(metric_pkg, function(nm) {
+  v <- tryCatch(as.character(utils::packageVersion(nm)),
+                error = function(e) NA_character_)
+  if (is.na(v)) nm else paste(nm, v)
+}, character(1))
 ref_types <- setdiff(unique(qual_metadata$ref), NA)
+
+# Pre-filter method: this pipeline uses {riskscore} to build the
+# initial candidate universe (see `dev/pkg_lists.R` and
+# val_prep_pipeline()). Report its installed version if available.
+# NA-suppressed row so an environment without riskscore installed
+# just omits the row rather than emitting "riskscore NA". See #138.
+prefilter_str <- tryCatch(
+  paste("riskscore",
+        as.character(utils::packageVersion("riskscore"))),
+  error = function(e) NA_character_
+)
 
 meta_rows <- list(
   c("Report generated",      format(Sys.time(), "%Y-%m-%d %H:%M:%S %Z")),
   c("Validation date(s)",    paste(val_dates, collapse = ", ")),
   c("R version",             paste(r_ver, collapse = ", ")),
-  c("Assessment reference",  paste(ref_types, collapse = ", ")),
-  c("Metric package",        paste(metric_pkg, collapse = ", ")),
-  c("Repositories",          paste(repos, collapse = "; "))
+  c("Assessment reference",  paste(ref_types, collapse = ", "))
 )
+if (!is.na(prefilter_str)) {
+  meta_rows <- c(meta_rows, list(
+    c("Pre-filter method",   prefilter_str)
+  ))
+}
+meta_rows <- c(meta_rows, list(
+  c("Metric package",        paste(metric_pkg_verstr, collapse = ", ")),
+  c("Repositories",          paste(repos, collapse = "; "))
+))
 # val.pipeline version(s) that produced this run. Sourced from the
 # per-pkg `val_pipeline_ver` list-col on qual_metadata (populated by
 # val_pkg() as of #130). A resumed run can span multiple versions if
@@ -191,6 +304,18 @@ if ("assessment_runtime_mins" %in% names(qual_metadata)) {
         format_hm(sum(rt_all)))
     ))
   }
+}
+# Wall-clock elapsed time from initial run kickoff -> now. Sourced
+# from val_pipeline.log's first `=== val_build() @ ... ===` banner.
+# Complements (does NOT replace) the cumulative row above: for a
+# resumed multi-session run the elapsed value includes the calendar
+# gaps between sessions, giving a more realistic "how long did this
+# take" answer. See #138.
+elapsed_mins <- elapsed_minutes_from_log(params$log_file_path)
+if (is.finite(elapsed_mins)) {
+  meta_rows <- c(meta_rows, list(
+    c("val_pipeline() runtime (elapsed)", format_hm(elapsed_mins))
+  ))
 }
 if (!is.null(params$n_candidates)) {
   meta_rows <- c(meta_rows, list(
@@ -404,12 +529,20 @@ itable(dropped_tbl, default_page_size = 25)
 The `final_decision` column reflects the risk category after dependency
 propagation (a package is downgraded if any dependency was Medium/High).
 
-```{r final-decision-counts}
-final_counts <- qual_metadata |>
-  dplyr::count(final_decision, .drop = FALSE, name = "packages") |>
-  dplyr::mutate(percent = sprintf("%.1f%%", 100 * packages / sum(packages)))
-kable(final_counts, col.names = c("Final decision", "Packages", "Percent"),
-      align = "lrr")
+```{r final-decision-counts, results = "asis"}
+# Cards replaced the table in this section per #138. Ordering:
+# Low -> Medium -> High so the palette green->yellow->red is
+# left-to-right. Levels that don't appear in the data (e.g. a run
+# that produced zero Medium) still render as 0-count cards so the
+# strip stays visually consistent across runs.
+risk_levels <- c("Low", "Medium", "High")
+present <- risk_levels[risk_levels %in% qual_metadata$final_decision]
+# Preserve `Low, Medium, High` order regardless of appearance order.
+counts_vec <- vapply(present, function(lvl) {
+  sum(qual_metadata$final_decision == lvl, na.rm = TRUE)
+}, integer(1))
+names(counts_vec) <- present
+render_risk_cards(counts_vec, total = nrow(qual_metadata))
 ```
 
 ## Initial vs. final decision
@@ -419,12 +552,23 @@ Packages whose category changed because of dependency propagation.
 ```{r decision-crosstab-downgrade-callout, results = "asis"}
 downgraded_n <- sum(qual_metadata$decision != qual_metadata$final_decision,
                     na.rm = TRUE)
-# Large-font callout above the crosstab so the reader's eye lands on
-# the headline number first. See #130.
-cat("::: {style=\"font-size: 1.8em; font-weight: bold; margin: 0.5em 0 0.75em;\"}\n",
-    format(downgraded_n, big.mark = ","),
-    " package(s) downgraded from their initial decision\n",
-    ":::\n", sep = "")
+# Downgrade count as a bordered, tinted infographic card so it visibly
+# separates from the surrounding section headers instead of blending
+# in as bold body text. Neutral pastel-orange fill mirrors a "watch"
+# tier semantics without hijacking the Low/Med/High palette used by
+# the risk cards below. See #138.
+cat(
+  "::: {style=\"display: inline-block; background-color: #FDE4B0; ",
+  "border: 1px solid rgba(0,0,0,0.15); border-radius: 8px; ",
+  "padding: 0.75em 1.25em; margin: 0.75em 0 1em;\"}\n",
+  "[",
+  format(downgraded_n, big.mark = ","),
+  "]{style=\"font-size: 2.4em; font-weight: bold; ",
+  "display: block; line-height: 1.1;\"}\n",
+  "package(s) downgraded from their initial decision\n",
+  ":::\n",
+  sep = ""
+)
 ```
 
 ```{r decision-crosstab}
@@ -600,6 +744,14 @@ if (nrow(incomplete) > 0L) {
 
 # Packages
 
+```{r packages-cards, results = "asis"}
+# Duplicate of the same card strip rendered under "Final decision
+# counts" above so a reader jumping directly to the per-tier tables
+# below gets the count / share at-a-glance without scrolling back.
+# See #138.
+render_risk_cards(counts_vec, total = nrow(qual_metadata))
+```
+
 The tables below list every package in each risk tier, with the reason and
 supporting note (driver metrics for `Risk Assessment`, failing dependency
 for `Dependency`, auto-accept metric list for `Auto-Accepted`). In HTML,
@@ -697,8 +849,10 @@ if (length(rt) > 0L) {
 
 ## Memory offenders
 
-Sourced as the 50 packages with the largest peak RSS during
-assessment; use the page-size control to browse fewer rows at a time.
+Sourced as the 50 packages with the largest peak RSS (Resident Set
+Size — the amount of physical memory the R worker process was
+holding at its peak, in MB) during assessment; use the page-size
+control to browse fewer rows at a time.
 
 ```{r mem-watchdog-load, include = FALSE}
 mw_path <- params$mem_watchdog_path


### PR DESCRIPTION
Closes #138.

## Run Metadata section

- **Elapsed time**: new row alongside cumulative runtime. Parsed from the first `=== val_build() @ <timestamp> ===` banner in `<val_dir>/val_pipeline.log` (`init_val_log()` writes this at `val_build()` entry, `R/verbosity.R:232`) and compared to `Sys.time()` at render. Elapsed includes calendar gaps between resumed sessions where cumulative does not -- both are shown.
- **Metric package**: now appends `utils::packageVersion()` at render time. Example: `riskmetric 0.2.5`.
- **Pre-filter method**: new row inserted immediately before `Metric package`. Value: `riskscore <version>`. Omitted when riskscore isn't installed.
- `val_pipeline_report()` passes a new `log_file_path` param to the template, populated from `<input_dir>/val_pipeline.log` when present.

## Downgrade callout

Upgraded from bare bold-text to a tinted bordered infographic card (pastel-orange `#FDE4B0`) so it separates visibly from surrounding section headers instead of blending. Palette deliberately outside Low/Med/High so it doesn't hijack tier semantics.

## Risk-level infographic cards

- New `render_risk_cards()` helper renders a horizontal card strip, one per risk tier, count + percent in large font.
- New `risk_palette()` helper: 3 tiers -> anchor triplet `#B7E4C7` / `#FFF3B0` / `#F8B4B4` (pastel green / yellow / red) directly. N > 3 tiers -> interpolate via `grDevices::colorRampPalette()` on the same anchors so the pattern generalizes to future 5-band schemes without changing callers.
- Cards render in **both** `Final decision counts` (replacing the previous table entirely per your confirmation) and the `Packages` header. Ordering hard-fixed as Low -> Medium -> High regardless of which tiers appear in the data, so the palette gradient always reads left-to-right.

## Memory offenders

Spell out **RSS = Resident Set Size** (in MB, peak) on first mention so readers unfamiliar with the term aren't left grepping.

## Typst-safety

New HTML div constructs use standard CSS (background-color / border / border-radius / padding / flex layout) and only `font-weight: bold` -- never numeric weights -- so they survive pandoc's html->typst conversion cleanly. #134's PDF regression guard was the whole point of adding that test.

## Verification

- `devtools::test(filter=\"val_pipeline_report\")` -> **64/64 pass, 0 skips** in ~117s. Includes the `format = \"pdf\"` typst render.

## Scope

Version bump 0.1.34 -> 0.1.35. Template + one helper param in `val_pipeline_report()` only.