### PR TITLE
Fix update_opt_repos() mangling PPM slug-with-date URLs (#140)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.35
+Version: 0.1.36
 Authors@R: 
   c(
     person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,14 @@
 
+# val.pipeline 0.1.36
+
+- Fix `update_opt_repos()` mangling PPM URLs whose slug encodes the
+  snapshot date (e.g. `.../cran-r4.5-2026-07-21/latest`). The old
+  nested `gsub()` swapped the slug's embedded date AND the `/latest`
+  tail, producing broken paths like `.../cran-r4.5-2026-07-21/2026-07-21/src/contrib`.
+  The rewrite now only touches the final path segment via
+  `dirname()`/`basename()`, and treats any URL whose slug already
+  encodes a date as authoritative (no-op). (#140)
+
 # val.pipeline 0.1.35
 
 - Summary report polish batch (#138):

--- a/R/utils.R
+++ b/R/utils.R
@@ -247,56 +247,64 @@ update_opt_repos <- function(
     val_date = Sys.Date(),
     opt_repos = getOption("repos")
 ) {
-  
-  if("CRAN" %in% toupper(names(opt_repos))) {
-    cran_pos <- which("CRAN" == toupper(names(opt_repos)))
-    curr_cran <- opt_repos[[cran_pos]]
-    # Grab the "base url", which will be the entire text string up till the last "/"
-    base_url <- dirname(curr_cran)
-    
-    # if val_date is today & curr_cran is already "latest" or ends in today's date, then don't update
-    if(val_date == Sys.Date()) {
-      if(stringr::str_detect(curr_cran, "latest") |
-         stringr::str_detect(curr_cran, as.character(Sys.Date()))
-      ) {
-        val_msg(paste0("\n--> 'CRAN' repo is already set to latest snapshot. No update needed.\n"),
-                min_level = "normal")
-        return(opt_repos)
-      } else {
-        val_msg(paste0("--> Updating 'CRAN' repo to use latest snapshot.\n"),
-                min_level = "normal")
-        new_cran <- file.path(base_url, "latest")
-        opt_repos[[cran_pos]] <- new_cran
-        return(opt_repos)
-      }
-    } else {
-      # if val_date is not today, then check"
-      # is val_date not being used at all?
-      if(!stringr::str_detect(curr_cran, as.character(val_date))) {
-        if(stringr::str_detect(curr_cran, "latest") |
-           stringr::str_detect(curr_cran, as.character(Sys.Date()))
-        ) {
-          val_msg(paste0("--> Updating 'CRAN' repo to use validation date: ", val_date, "\n"),
-                  min_level = "normal")
-          new_cran <- gsub("latest", as.character(val_date), 
-              gsub("\\d{4}-\\d{2}-\\d{2}", as.character(val_date), curr_cran)
-          )
-        } else {
-          val_msg(paste0("\n--> 'CRAN' repo is currently set to use date: ", stringr::str_extract(curr_cran, "\\d{4}-\\d{2}-\\d{2}"), "\n"),
-                  min_level = "normal")
-          old_date <- stringr::str_extract(curr_cran, "\\d{4}-\\d{2}-\\d{2}")
-          if(!is.na(old_date)) {
-            new_cran <- gsub(old_date, as.character(val_date), curr_cran)
-          } else {
-            new_cran <- paste0(base_url, as.character(val_date))
-          }
-        }
-        
-        opt_repos[[cran_pos]] <- new_cran
 
-      } # else val_date was found
-    }
+  if (is.null(opt_repos) || length(opt_repos) == 0) return(opt_repos)
+  if (!"CRAN" %in% toupper(names(opt_repos))) return(opt_repos)
+
+  cran_pos <- which("CRAN" == toupper(names(opt_repos)))
+  curr_cran <- opt_repos[[cran_pos]]
+  val_date_chr <- as.character(val_date)
+
+  # Only ever rewrite the FINAL path segment (the snapshot "tail").
+  # PPM URLs like `.../cran-r4.5-2026-07-21/latest` embed a fixed
+  # snapshot date in the repo slug -- swapping dates anywhere else
+  # in the URL corrupts the slug and 404s. See #140.
+  base_url <- dirname(curr_cran)
+  tail <- basename(curr_cran)
+
+  slug_has_date <- grepl("\\d{4}-\\d{2}-\\d{2}", base_url)
+  tail_is_latest <- identical(tail, "latest")
+  tail_is_date <- grepl("^\\d{4}-\\d{2}-\\d{2}$", tail)
+
+  # Config is authoritative when the slug already encodes a snapshot
+  # date -- e.g. PPM's `<repo>-<date>/latest` frozen-mirror pattern.
+  if (slug_has_date && tail_is_latest) {
+    val_msg(paste0("\n--> 'CRAN' repo slug already encodes a snapshot date; ",
+                   "leaving config URL untouched (", curr_cran, ").\n"),
+            min_level = "normal")
+    return(opt_repos)
   }
+
+  if (val_date_chr == as.character(Sys.Date())) {
+    if (tail_is_latest || tail == val_date_chr) {
+      val_msg("\n--> 'CRAN' repo is already set to latest snapshot. No update needed.\n",
+              min_level = "normal")
+      return(opt_repos)
+    }
+    val_msg("--> Updating 'CRAN' repo to use latest snapshot.\n",
+            min_level = "normal")
+    opt_repos[[cran_pos]] <- file.path(base_url, "latest")
+    return(opt_repos)
+  }
+
+  # val_date != today
+  if (tail_is_date) {
+    if (tail == val_date_chr) return(opt_repos)  # already correct
+    val_msg(paste0("\n--> 'CRAN' repo is currently set to use date: ", tail, "\n"),
+            min_level = "normal")
+    opt_repos[[cran_pos]] <- file.path(base_url, val_date_chr)
+    return(opt_repos)
+  }
+
+  if (tail_is_latest) {
+    val_msg(paste0("--> Updating 'CRAN' repo to use validation date: ",
+                   val_date_chr, "\n"),
+            min_level = "normal")
+    opt_repos[[cran_pos]] <- file.path(base_url, val_date_chr)
+    return(opt_repos)
+  }
+
+  # Unrecognized tail (e.g. custom path suffix) -- leave untouched.
   return(opt_repos)
 }
   

--- a/tests/testthat/test-update_opt_repos.R
+++ b/tests/testthat/test-update_opt_repos.R
@@ -74,3 +74,54 @@ test_that("update_opt_repos() handles NULL repos", {
   expect_null(result)
 })
 
+# --- #140: PPM URLs with date-encoded slug ---
+
+test_that("update_opt_repos() leaves PPM slug-with-date + /latest untouched", {
+  # PPM frozen-mirror pattern: the slug encodes the snapshot date, and
+  # `/latest` is the canonical tail. The URL must not be rewritten.
+  mock_repos <- c(
+    CRAN = "https://sce-ppm-test.arcusbio.com/cran-r4.5-2026-07-21/latest"
+  )
+  val_date <- as.Date("2026-07-21")
+
+  expect_output(
+    result <- update_opt_repos(val_date, mock_repos),
+    "slug already encodes a snapshot date"
+  )
+  expect_equal(result[["CRAN"]], mock_repos[["CRAN"]])
+})
+
+test_that("update_opt_repos() leaves PPM slug URL alone even when val_date drifts", {
+  # If the operator wrote a date-frozen slug into the config, treat it as
+  # authoritative regardless of val_date drift. Users who want date-swap
+  # behavior can drop the date from the slug or set freeze_opt_repos.
+  mock_repos <- c(
+    CRAN = "https://sce-ppm-test.arcusbio.com/cran-r4.5-2026-07-21/latest"
+  )
+  val_date <- as.Date("2026-08-15")
+
+  expect_output(
+    result <- update_opt_repos(val_date, mock_repos),
+    "slug already encodes a snapshot date"
+  )
+  expect_equal(result[["CRAN"]], mock_repos[["CRAN"]])
+})
+
+test_that("update_opt_repos() never introduces a date into the slug segment", {
+  # Regression: the old nested-gsub could produce
+  # `.../cran-r4.5-2026-07-21/2026-07-21/src/contrib` by rewriting both
+  # the slug date and the /latest tail.
+  mock_repos <- c(
+    CRAN = "https://sce-ppm-test.arcusbio.com/cran-r4.5-2026-07-21/latest"
+  )
+  val_date <- as.Date("2024-06-01")
+
+  suppressMessages(
+    result <- update_opt_repos(val_date, mock_repos)
+  )
+  # Should NOT contain a doubled date path segment
+  expect_false(
+    grepl("cran-r4\\.5-2026-07-21/\\d{4}-\\d{2}-\\d{2}", result[["CRAN"]])
+  )
+})
+


### PR DESCRIPTION
Closes #140.

## Problem

For PPM URLs whose slug encodes the snapshot date (e.g.
`https://sce-ppm-test.arcusbio.com/cran-r4.5-2026-07-21/latest`),
`update_opt_repos()` produced a broken URL:

```
Warning: unable to access index for repository
  https://sce-ppm-test.arcusbio.com/cran-r4.5-2026-07-21/2026-07-21/src/contrib
```

Root cause was in `R/utils.R:282-286`:

```r
new_cran <- gsub("latest", as.character(val_date),
    gsub("\\d{4}-\\d{2}-\\d{2}", as.character(val_date), curr_cran)
)
```

The inner `gsub` was unanchored: it rewrote the `YYYY-MM-DD` embedded in the PPM slug, then the outer `gsub` replaced the `/latest` tail with `/<val_date>`. Result: a URL with a date-form path segment glued onto a slug PPM only serves at `/latest`.

## Fix

Rewrite `update_opt_repos()` to operate only on the final path segment via `dirname()`/`basename()`, never touching date substrings elsewhere in the URL. When the slug already encodes a date and the tail is `latest`, treat the config URL as authoritative (no-op) — matching PPM's frozen-mirror convention.

## Behavior matrix

| curr_cran | val_date | before | after |
|---|---|---|---|
| `.../cran/2024-01-01` | 2024-06-01 | `.../cran/2024-06-01` ✅ | `.../cran/2024-06-01` ✅ |
| `.../cran/latest` | today | no-op ✅ | no-op ✅ |
| `.../cran/2024-01-01` | today | `.../cran/latest` ✅ | `.../cran/latest` ✅ |
| `.../cran-r4.5-2026-07-21/latest` | 2026-07-21 | `.../cran-r4.5-2026-07-21/2026-07-21` ❌ | no-op ✅ |
| `.../cran-r4.5-2026-07-21/latest` | 2026-08-15 | `.../cran-r4.5-2026-08-15/2026-08-15` ❌ | no-op ✅ |

## Verification

- `devtools::test(filter = "update_opt_repos")` → 16/16 pass (13 existing + 3 new regression tests).
- New tests cover the PPM slug pattern with matching and drifting val_dates, plus an anti-regression assertion that a doubled-date path segment cannot be produced.

Also removes the `stringr::str_detect` / `str_extract` calls from this function in favor of base `grepl`.

## Notes

- The `freeze_opt_repos = TRUE` escape hatch remains fully functional; it's just no longer needed for correctly-formed PPM URLs.
- No new dependencies, no upstream shim required.