### PR TITLE
Bump riskscore requirement to >= 0.1.3, pin Remotes to @latest (#142)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: val.pipeline
 Title: Validation Pipeline Example
-Version: 0.1.36
+Version: 0.1.37
 Authors@R: 
   c(
     person(
@@ -52,7 +52,7 @@ Imports:
     reactable,
     riskmetric (>= 0.2.7),
     riskreports (>= 0.0.0.9006),
-    riskscore (>= 0.1.1),
+    riskscore (>= 0.1.3),
     rlang,
     stringr,
     tibble,
@@ -62,7 +62,6 @@ Imports:
 Remotes: 
     pharmaR/riskmetric,
     pharmaR/riskreports,
-    Sanofi-Public/risk.assessr,
-    pharmar/riskscore
+    pharmar/riskscore@latest
 Depends: 
     R (>= 4.1.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 
+# val.pipeline 0.1.37
+
+- Bump the minimum `{riskscore}` requirement to `>= 0.1.3` and pin the
+  `Remotes:` entry to `pharmar/riskscore@latest` so `remotes` /
+  `renv::restore()` pull from the branch that actually ships the
+  compiled `assessed_latest` / `scored_latest` datasets. Refresh the
+  stale `val_categorize()` docstring accordingly. (#142)
+
 # val.pipeline 0.1.36
 
 - Fix `update_opt_repos()` mangling PPM URLs whose slug encodes the

--- a/R/val_decision.R
+++ b/R/val_decision.R
@@ -229,7 +229,8 @@ val_decision <- function(
 #' used to set thresholds (and later update final decision (if not already 'high
 #' risk')) AND filter packages before running val_build(). Note: If PACKAGES
 #' file had assessments, we'd be using that (paired with \{val.filter\}), but
-#' instead, we're going to use riskscore::latest for the time being
+#' instead, we use `riskscore::assessed_latest` / `riskscore::scored_latest`
+#' (compiled from the `latest` branch of pharmar/riskscore).
 #'
 #' @param source character, either "riskscore" (default), "PACKAGES", or a
 #'   data.frame.
@@ -271,7 +272,7 @@ val_categorize <- function(
     # Use "pkg_cran_remote" data from riskscore::cran_assessed_latest
     # remotes::install_github("pharmar/riskscore", force = TRUE,
     #                         ref = "latest")
-    pv <- utils::packageVersion("riskscore") # verify ‘v0.1.1'
+    pv <- utils::packageVersion("riskscore")
     riskscore_run_date <- riskscore::assessed_latest$riskmetric_run_date |> unique()
     val_msg(paste0("\n--> Using {riskscore} Version: 'v", pv, "', last compiled on '",
                    riskscore_run_date,"'.\n"),

--- a/man/val_categorize.Rd
+++ b/man/val_categorize.Rd
@@ -31,5 +31,6 @@ First whack at attempting to filter packages based on org-level criterion
 used to set thresholds (and later update final decision (if not already 'high
 risk')) AND filter packages before running val_build(). Note: If PACKAGES
 file had assessments, we'd be using that (paired with \{val.filter\}), but
-instead, we're going to use riskscore::latest for the time being
+instead, we use \code{riskscore::assessed_latest} / \code{riskscore::scored_latest}
+(compiled from the \code{latest} branch of pharmar/riskscore).
 }

--- a/renv.lock
+++ b/renv.lock
@@ -3195,7 +3195,7 @@
     },
     "riskscore": {
       "Package": "riskscore",
-      "Version": "0.1.2",
+      "Version": "0.1.3",
       "Source": "GitHub",
       "Title": "A Catalog for `riskmetric` Results Across Public Repositories",
       "Authors@R": "c(  person(\"Aaron\", \"Clark\", , \"clark.aaronchris@gmail.com\", role = c(\"cre\", \"aut\"), comment = c(ORCID = \"0000-0002-0123-0970\")), person(family = \"R Validation Hub\", role = c(\"cph\", \"fnd\")) )",
@@ -3220,7 +3220,7 @@
       "RemoteRepo": "riskscore",
       "RemoteUsername": "pharmar",
       "RemoteRef": "latest",
-      "RemoteSha": "64b1335f1c277e42f4fec684dd3de2d011e54914",
+      "RemoteSha": "1f9df6dddc1a0c654c1d681042c26788159cf7e3",
       "NeedsCompilation": "no",
       "Author": "Aaron Clark [cre, aut] (ORCID: <https://orcid.org/0000-0002-0123-0970>), R Validation Hub [cph, fnd]",
       "Maintainer": "Aaron Clark <clark.aaronchris@gmail.com>"


### PR DESCRIPTION
Closes #142. Bumps 0.1.36 → 0.1.37.

Small housekeeping PR to align val.pipeline with [riskscore 0.1.3](https://github.com/pharmar/riskscore/tree/latest) (compiled 2026-08-15).

## Changes

- `DESCRIPTION`:
  - `riskscore (>= 0.1.1)` → `riskscore (>= 0.1.3)`
  - `Remotes: pharmar/riskscore` → `pharmar/riskscore@latest` — matches what `renv.lock` was already installing (`RemoteRef: latest`), and ensures `remotes::install_github()` / `renv::restore()` pull from the branch that actually ships the compiled `assessed_latest` / `scored_latest` datasets. The `main` branch does not.
- `R/val_decision.R`: refresh stale `val_categorize()` docstring; drop stale `# verify 'v0.1.1'` marker. Regenerate `man/val_categorize.Rd`.
- `NEWS.md`: entry.

## What's intentionally NOT changed

The `left_join(riskscore::assessed_latest, ...)` and `left_join(riskscore::scored_latest, ...)` calls remain as-is. Per Aaron: keep flagged (`pkg_missing = TRUE`) rows flowing through the existing join logic unchanged.

## Verification

- Syntax parses.
- Full `devtools::test()` / R CMD check will run in CI once merged (local env can't load val.pipeline until Aaron refreshes renv.lock with riskscore 0.1.3).
- Diff: 4 files, +16/-6.